### PR TITLE
require Sphinx >= 1.5.1 for rtd

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -8,5 +8,6 @@ dependencies:
     - Cython
     - matplotlib
     - numpy
+    - Sphinx >= 1.5.1
 #   - pip:
 #       - dependency_from_pip


### PR DESCRIPTION
Try setting a Sphinx  dependency to >= 1.5.1 which is what you're probably using in astroconda?  It looks like RTD is pulling 1.3.5. The error suggests whatever you're doing with caption might be version related. I had no problem in my env either. 

```
The following NEW packages will be INSTALLED:

alabaster: 0.7.10-py27_0
babel: 2.3.4-py27_0
docutils: 0.12-py27_2
funcsigs: 1.0.2-py27_0
jbig: 2.1-0
jinja2: 2.9.5-py27_0
libtiff: 4.0.6-2
markupsafe: 0.23-py27_2
mock: 2.0.0-py27_0
pbr: 1.10.0-py27_0
pillow: 3.0.0-py27_1
pygments: 2.1.1-py27_0
snowballstemmer: 1.2.1-py27_0
sphinx: 1.3.5-py27_0
sphinx_rtd_theme: 0.1.7-py27_0
xz: 5.2.2-1 
```
