### PR TITLE
Fix the output units of CCM89 - correct is A(X)/A(V)

### DIFF
--- a/dust_extinction/dust_extinction.py
+++ b/dust_extinction/dust_extinction.py
@@ -23,7 +23,7 @@ class BaseExtRvModel(Model):
     Base Extinction R(V)-dependent Model.  Do not use.
     """
     inputs = ('x',)
-    outputs = ('exvebv',)
+    outputs = ('axav',)
     
     Rv = Parameter(description="R(V) = A(V)/E(B-V) = " \
                    + "total-to-selective extinction",
@@ -75,7 +75,7 @@ class BaseExtRvModel(Model):
            fractional extinction as a function of x 
         """
         # get the extinction curve
-        exvebv = self(x)
+        axav = self(x)
 
         # check that av or ebv is set
         if (Av is None) and (Ebv is None):
@@ -85,9 +85,6 @@ class BaseExtRvModel(Model):
         if Av is None:
             Av = self.Rv*Ebv
         
-        # convert to A(x)/A(V)
-        axav = exvebv/self.Rv + 1
-
         # return fractional extinction
         return np.power(10.0,-0.4*axav*Av)
         
@@ -137,7 +134,7 @@ class CCM89(BaseExtRvModel):
            ax.plot(x,ext_model(x),label='R(V) = ' + str(cur_Rv))
 
         ax.set_xlabel('$x$ [$\mu m^{-1}$]')
-        ax.set_ylabel('$E(\lambda - V)/E(B - V)$')
+        ax.set_ylabel('$A(x)/A(V)$')
     
         ax.legend(loc='best')
         plt.show()
@@ -160,8 +157,8 @@ class CCM89(BaseExtRvModel):
 
         Returns
         -------
-        exvebv: np array (float)
-            E(x-V)/E(B-V) extinction curve [mag]
+        axav: np array (float)
+            A(x)/A(V) extinction curve [mag]
 
         Raises
         ------
@@ -228,7 +225,7 @@ class CCM89(BaseExtRvModel):
         a[fuv_indxs] = np.polyval((-.070, .137, -.628, -1.073), y)
         b[fuv_indxs] = np.polyval((.374, -.42, 4.257, 13.67), y)
 
-        # return E(lambda-V)/E(B-V)
+        # return A(x)/A(V)
         return a + b/Rv
 
 class FM90(Model):

--- a/dust_extinction/tests/test_ccm89.py
+++ b/dust_extinction/tests/test_ccm89.py
@@ -63,7 +63,7 @@ def test_invalid_micron(x_invalid_angstrom):
                                 + str(tmodel.x_range[1]) \
                                 + ', x has units 1/micron]'
 
-def test_elvebv_ccm89_table3():
+def test_axav_ccm89_table3():
     # values from Table 3 of Cardelli et al. (1989)
     #   ignoring the last value at L band as it is outside the
     #   valid range for the relationship
@@ -80,7 +80,7 @@ def test_elvebv_ccm89_table3():
     # test (table in paper has limited precision)
     np.testing.assert_allclose(tmodel(x), cor_vals, atol=1e-2)
     
-def get_elvebv_cor_vals(Rv):
+def get_axav_cor_vals(Rv):
     # testing wavenumbers
     x = np.array([ 10.  ,   9.  ,   8.  ,   7.  ,
                    6.  ,   5.  ,   4.6 ,   4.  ,
@@ -137,7 +137,7 @@ def get_elvebv_cor_vals(Rv):
 @pytest.mark.parametrize("Rv", [2.0, 3.0, 3.1, 4.0, 5.0, 6.0])
 def test_extinction_CCM89_values(Rv):
     # get the correct values
-    x, cor_vals = get_elvebv_cor_vals(Rv)
+    x, cor_vals = get_axav_cor_vals(Rv)
     
     # initialize extinction model    
     tmodel = CCM89(Rv=Rv)
@@ -154,11 +154,11 @@ def test_extinguish_no_av_or_ebv():
 @pytest.mark.parametrize("Rv", [2.0, 3.0, 3.1, 4.0, 5.0, 6.0])
 def test_extinction_CCM89_extinguish_values_Av(Rv):
     # get the correct values
-    x, cor_vals = get_elvebv_cor_vals(Rv)
+    x, cor_vals = get_axav_cor_vals(Rv)
 
     # calculate the cor_vals in fractional units
     Av = 1.0
-    cor_vals = np.power(10.0,-0.4*(cor_vals/Rv+1)*Av)
+    cor_vals = np.power(10.0,-0.4*(cor_vals*Av))
     
     # initialize extinction model    
     tmodel = CCM89(Rv=Rv)
@@ -169,12 +169,12 @@ def test_extinction_CCM89_extinguish_values_Av(Rv):
 @pytest.mark.parametrize("Rv", [2.0, 3.0, 3.1, 4.0, 5.0, 6.0])
 def test_extinction_CCM89_extinguish_values_Ebv(Rv):
     # get the correct values
-    x, cor_vals = get_elvebv_cor_vals(Rv)
+    x, cor_vals = get_axav_cor_vals(Rv)
 
     # calculate the cor_vals in fractional units
     Ebv = 1.0
     Av = Ebv*Rv
-    cor_vals = np.power(10.0,-0.4*(cor_vals/Rv+1)*Av)
+    cor_vals = np.power(10.0,-0.4*(cor_vals*Av))
     
     # initialize extinction model    
     tmodel = CCM89(Rv=Rv)


### PR DESCRIPTION
Had the wrong units as output for CCM89 - stated it was E(x-V)/E(B-V), but really it was A(x)/A(V).  Fixed.