### PR TITLE
Update astropy-helpers to v2.0.6

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -19,9 +19,14 @@ that section, and options therein, determine the next step taken:  If it
 contains an option called ``auto_use`` with a value of ``True``, it will
 automatically call the main function of this module called
 `use_astropy_helpers` (see that function's docstring for full details).
-Otherwise no further action is taken (however,
-``ah_bootstrap.use_astropy_helpers`` may be called manually from within the
-setup.py script).
+Otherwise no further action is taken and by default the system-installed version
+of astropy-helpers will be used (however, ``ah_bootstrap.use_astropy_helpers``
+may be called manually from within the setup.py script).
+
+This behavior can also be controlled using the ``--auto-use`` and
+``--no-auto-use`` command-line flags. For clarity, an alias for
+``--no-auto-use`` is ``--use-system-astropy-helpers``, and we recommend using
+the latter if needed.
 
 Additional options in the ``[ah_boostrap]`` section of setup.cfg have the same
 names as the arguments to `use_astropy_helpers`, and can be used to configure
@@ -137,7 +142,6 @@ import pkg_resources
 
 from setuptools import Distribution
 from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
 
 from distutils import log
 from distutils.debug import DEBUG
@@ -146,6 +150,11 @@ from distutils.debug import DEBUG
 # TODO: Maybe enable checking for a specific version of astropy_helpers?
 DIST_NAME = 'astropy-helpers'
 PACKAGE_NAME = 'astropy_helpers'
+
+if PY3:
+    UPPER_VERSION_EXCLUSIVE = None
+else:
+    UPPER_VERSION_EXCLUSIVE = '3'
 
 # Defaults for other options
 DOWNLOAD_IF_NEEDED = True
@@ -286,6 +295,18 @@ class _Bootstrapper(object):
         if '--offline' in argv:
             config['offline'] = True
             argv.remove('--offline')
+
+        if '--auto-use' in argv:
+            config['auto_use'] = True
+            argv.remove('--auto-use')
+
+        if '--no-auto-use' in argv:
+            config['auto_use'] = False
+            argv.remove('--no-auto-use')
+
+        if '--use-system-astropy-helpers' in argv:
+            config['auto_use'] = False
+            argv.remove('--use-system-astropy-helpers')
 
         return config
 
@@ -464,9 +485,10 @@ class _Bootstrapper(object):
             # setup.py exists we can generate it
             setup_py = os.path.join(path, 'setup.py')
             if os.path.isfile(setup_py):
-                with _silence():
-                    run_setup(os.path.join(path, 'setup.py'),
-                              ['egg_info'])
+                # We use subprocess instead of run_setup from setuptools to
+                # avoid segmentation faults - see the following for more details:
+                # https://github.com/cython/cython/issues/2104
+                sp.check_output([sys.executable, 'setup.py', 'egg_info'], cwd=path)
 
                 for dist in pkg_resources.find_distributions(path, True):
                     # There should be only one...
@@ -501,16 +523,32 @@ class _Bootstrapper(object):
         if version:
             req = '{0}=={1}'.format(DIST_NAME, version)
         else:
-            req = DIST_NAME
+            if UPPER_VERSION_EXCLUSIVE is None:
+                req = DIST_NAME
+            else:
+                req = '{0}<{1}'.format(DIST_NAME, UPPER_VERSION_EXCLUSIVE)
 
         attrs = {'setup_requires': [req]}
 
+        # NOTE: we need to parse the config file (e.g. setup.cfg) to make sure
+        # it honours the options set in the [easy_install] section, and we need
+        # to explicitly fetch the requirement eggs as setup_requires does not
+        # get honored in recent versions of setuptools:
+        # https://github.com/pypa/setuptools/issues/1273
+
         try:
-            if DEBUG:
-                _Distribution(attrs=attrs)
-            else:
-                with _silence():
-                    _Distribution(attrs=attrs)
+
+            context = _verbose if DEBUG else _silence
+            with context():
+                dist = _Distribution(attrs=attrs)
+                try:
+                    dist.parse_config_files(ignore_option_errors=True)
+                    dist.fetch_build_eggs(req)
+                except TypeError:
+                    # On older versions of setuptools, ignore_option_errors
+                    # doesn't exist, and the above two lines are not needed
+                    # so we can just continue
+                    pass
 
             # If the setup_requires succeeded it will have added the new dist to
             # the main working_set
@@ -845,6 +883,10 @@ class _DummyFile(object):
     def flush(self):
         pass
 
+
+@contextlib.contextmanager
+def _verbose():
+    yield
 
 @contextlib.contextmanager
 def _silence():

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -6,6 +6,8 @@ Setuptools bootstrapping installer.
 Maintained at https://github.com/pypa/setuptools/tree/bootstrap.
 
 Run this script to install or upgrade setuptools.
+
+This method is DEPRECATED. Check https://github.com/pypa/setuptools/issues/581 for more details.
 """
 
 import os
@@ -18,29 +20,28 @@ import subprocess
 import platform
 import textwrap
 import contextlib
-import json
-import codecs
 
 from distutils import log
 
 try:
     from urllib.request import urlopen
-    from urllib.parse import urljoin
 except ImportError:
     from urllib2 import urlopen
-    from urlparse import urljoin
 
 try:
     from site import USER_SITE
 except ImportError:
     USER_SITE = None
 
-LATEST = object()
-DEFAULT_VERSION = LATEST
+# 33.1.1 is the last version that supports setuptools self upgrade/installation.
+DEFAULT_VERSION = "33.1.1"
 DEFAULT_URL = "https://pypi.io/packages/source/s/setuptools/"
 DEFAULT_SAVE_DIR = os.curdir
+DEFAULT_DEPRECATION_MESSAGE = "ez_setup.py is deprecated and when using it setuptools will be pinned to {0} since it's the last version that supports setuptools self upgrade/installation, check https://github.com/pypa/setuptools/issues/581 for more info; use pip to install setuptools"
 
 MEANINGFUL_INVALID_ZIP_ERR_MSG = 'Maybe {0} is corrupted, delete it and try again.'
+
+log.warn(DEFAULT_DEPRECATION_MESSAGE.format(DEFAULT_VERSION))
 
 
 def _python_cmd(*args):
@@ -157,7 +158,6 @@ def use_setuptools(
     Return None. Raise SystemExit if the requested version
     or later cannot be installed.
     """
-    version = _resolve_version(version)
     to_dir = os.path.abspath(to_dir)
 
     # prior to importing, capture the module state for
@@ -344,7 +344,6 @@ def download_setuptools(
     ``downloader_factory`` should be a function taking no arguments and
     returning a function for downloading a URL to a target.
     """
-    version = _resolve_version(version)
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
     zip_name = "setuptools-%s.zip" % version
@@ -355,27 +354,6 @@ def download_setuptools(
         downloader = downloader_factory()
         downloader(url, saveto)
     return os.path.realpath(saveto)
-
-
-def _resolve_version(version):
-    """
-    Resolve LATEST version
-    """
-    if version is not LATEST:
-        return version
-
-    meta_url = urljoin(DEFAULT_URL, '/pypi/setuptools/json')
-    resp = urlopen(meta_url)
-    with contextlib.closing(resp):
-        try:
-            charset = resp.info().get_content_charset()
-        except Exception:
-            # Python 2 compat; assume UTF-8
-            charset = 'UTF-8'
-        reader = codecs.getreader(charset)
-        doc = json.load(reader(resp))
-
-    return str(doc['info']['version'])
 
 
 def _build_install_args(options):


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.6. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed. 

A full list of changes can be found in the [changelog](https://github.com/astropy/astropy-helpers/blob/v2.0.6/CHANGES.rst). 

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!* 

Along with with the astropy core release v3.0, we have also started to release astropy-helpers v3.0.x versions. Similarly to the core package, these require Python 3.5+. We will open automated update PRs with astropy-helpers v3.0.x only for packages that specifically opt in for it when they start supporting Python 3.5+ only. Please let @bsipocz or @astrofrog know or add your package to the list in https://github.com/astropy/astropy-procedures/blob/master/update-affiliated/helpers_3.py