### PR TITLE
WIP: Adding in extinction versus attenuation docs

### DIFF
--- a/docs/dust_extinction/extinction.rst
+++ b/docs/dust_extinction/extinction.rst
@@ -1,0 +1,97 @@
+.. _ExtvsAtt:
+
+#############################
+Extinction versus Attenuation
+#############################
+
+Extinction
+==========
+
+Interstellar dust extinction is the result of photons being absorbed or
+scattered *out* of the line-of-sight by dust grains.
+
+Extinction can be directly measured by observing a star with dust along the
+line-of-sight. Knowledge of the intrinsic spectrum of the star from either an
+observation of a similar star without dust along the line-of-sight or a stellar
+atmosphere model is used.
+
+Extinction can be directly measured towards individual stars.  The specific
+geometry is a star with a column of dust between the observer and the star. The
+two effects present are dust grains absorbing photons or scattering photons out
+of the line-of-sight.  Since the dust grains are not near the star, scattering
+of photons from the star into the line-of-sight is very small  and can be safely
+ignored.
+
+Both dust absorption and scattering out of the line-of-sight are processes
+that are directly proportional to the amount of dust along the line-of-sight.
+As a result, the ratio of dust extinctions at two different wavelengths
+does not vary with different amounts of dust.  In other words, extinction
+curves normalized by dust column measured towards different different stars
+with different amounts of identical dust grains are equivalent.  This is
+illustrated below where the left plot shows the total extinction as a function
+of wavelength and the right plot shows the same curves normalized by A(V).
+
+.. plot::
+
+   import numpy as np
+   import matplotlib.pyplot as plt
+   import astropy.units as u
+
+   from dust_extinction.averages import GCC09_MWAvg
+
+   fig, ax = plt.subplots(ncols=2)
+
+   # generate the curves and plot them
+   x = np.arange(0.3,10.0,0.1)/u.micron
+   ext_model = GCC09_MWAvg()
+
+   ax[0].plot(x,ext_model(x)*0.5,label='A(V) = 0.5 mag')
+   ax[0].plot(x,ext_model(x)*1.5,label='A(V) = 1.5 mag')
+   ax[0].plot(x,ext_model(x)*2.5,label='A(V) = 2.5 mag')
+
+   ax[1].plot(x,ext_model(x),label='A(V) = 0.5 mag')
+   ax[1].plot(x,ext_model(x),label='A(V) = 1.5 mag')
+   ax[1].plot(x,ext_model(x),label='A(V) = 2.5 mag')
+
+   ax[0].set_title('Total Extinction')
+   ax[1].set_title('Normalized Extinction')
+   ax[0].set_xlabel('$x$ [$\mu m^{-1}$]')
+   ax[1].set_xlabel('$x$ [$\mu m^{-1}$]')
+   ax[0].set_ylabel('$A(x)$')
+   ax[1].set_ylabel('$A(x)/A(V)$')
+
+   ax[0].legend(loc='best')
+   ax[1].legend(loc='best')
+   plt.tight_layout()
+   plt.show()
+
+Note that there is dust scattered light throughout a galaxy due to the all the
+stars and dust in that galaxy.  For our Galaxy, this is called the  Diffuse
+Galactic Light (DGL). This overall scattered light is removed from observations
+of a single star by the standard practice of subtracting a local background.
+The overall scattered light is smooth on the usual spatial scales involved in
+measuring a single star.
+
+Attenuation
+===========
+
+Dust attenuation refers to the general impact on the spectrum of an object due
+to the presence of dust.  In general, attenuation is used to indicate that the
+geometry of the sources and dust in a system is more complex than a single star
+with a foreground screen of dust.  Examples of such systems include dusty
+galaxies (composed of many stars) and  stars with circumstellar dust.
+
+Attenuation includes two additional effects not include in extinction. These are
+scattering of photons into the observation beam and sources extinguished by
+different columns of dust.  These two additional sources results in the ratio of
+dust attenuations at two different wavelengths does *varies* with different
+amounts total system dust.  These two additional effects mean that the
+measurement and/or theoretical calculation of attenuation is significantly more
+complex than for extinction.
+
+The separate package `dust_attenuation package
+<http://dust-attenuation.readthedocs.io/>`_ exists to provide attenuation
+models.
+
+Note: all extinction curves are attenuation curves, but not all attenuation
+curves are extinction curves.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,22 +2,18 @@
 Interstellar Dust Extinction
 ############################
 
-``dust_extinction`` is a python package to provide models of
-interstellar dust extinction curves.
+``dust_extinction`` is a python package to provide models of interstellar dust
+extinction curves.
 
-Extinction describes the effects of dust on a single star.  The dust along
-the line-of-sight to the stars removes flux by absorbing photons or scattering
-photons out of the line-of-sight.  In general, extinction models are used
-to model or correct the effects of dust on observations a single star.
+Extinction describes the effects of dust on a single star.  The dust along the
+line-of-sight to the stars removes flux by absorbing photons or scattering
+photons out of the line-of-sight.  In general, extinction models are used to
+model or correct the effects of dust on observations a single star.
 
-In contrast, dust attenuation refers to the effects of dust on the
-measurements of groups of stars mixed with dust.  The effects
-include in attenuation are dust absorption, dust scattering out of the
-line-of-sight, and dust scattering into the line-of-sight.  In general,
-attenuation models are used to model or correct the effects of dust on
-observations of region of galaxies or global measurements of galaxies.
-For attenuation models, see
-the `dust_attenuation package <http://dust-attenuation.readthedocs.io/>`_.
+In contrast, dust attenuation refers to the effects of dust on the measurements
+of groups of stars mixed with dust or stars with circumstellar dust.
+See :ref:`ExtvsAtt`.  For attenuation models, see the `dust_attenuation
+package <http://dust-attenuation.readthedocs.io/>`_.
 
 This package is an
 `astropy affiliated package <http://www.astropy.org/affiliated/>`_
@@ -31,6 +27,7 @@ User Documentation
 .. toctree::
    :maxdepth: 2
 
+   Extinction versus Attenuation <dust_extinction/extinction.rst>
    Flavors of Models <dust_extinction/model_flavors.rst>
    Extinguish (or unextinguish) data <dust_extinction/extinguish.rst>
    Fitting extinction curves <dust_extinction/fit_extinction.rst>
@@ -55,8 +52,8 @@ Quick Start
 
 How to extinguish (redden) and unextinguish (deredden) a spectrum:
 
-Generate a spectrum to use.  In this case a blackbody model, but can be
-an observed spectrum.  The `dust_extinction` models are unit aware and the
+Generate a spectrum to use.  In this case a blackbody model, but can be an
+observed spectrum.  The `dust_extinction` models are unit aware and the
 wavelength array should have astropy.units associated with it.
 
 .. code-block:: python
@@ -79,9 +76,9 @@ Define a model, specifically the F99 model with an R(V) = 3.1.
     # define the model
     ext = F99(Rv=3.1)
 
-Extinguish (redden) a spectrum with a screen of F99 dust with
-an E(B-V) of 0.5.  Can also specify the dust column with Av
-(this case equivalent to Av = 0.5*Rv = 1.55).
+Extinguish (redden) a spectrum with a screen of F99 dust with an E(B-V) of 0.5.
+Can also specify the dust column with Av (this case equivalent to Av = 0.5*Rv =
+1.55).
 
 .. code-block:: python
 
@@ -135,8 +132,6 @@ equivalent A(V) column.
     plt.tight_layout()
     plt.show()
 
-
-
 Reporting Issues
 ================
 
@@ -144,26 +139,23 @@ If you have found a bug in ``dust_extinction`` please report it by creating a
 new issue on the ``dust_extinction`` `GitHub issue tracker
 <https://github.com/karllark/dust_extinction/issues>`_.
 
-Please include an example that demonstrates the issue sufficiently so that
-the developers can reproduce and fix the problem. You may also be asked to
-provide information about your operating system and a full Python
-stack trace.  The developers will walk you through obtaining a stack
-trace if it is necessary.
+Please include an example that demonstrates the issue sufficiently so that the
+developers can reproduce and fix the problem. You may also be asked to provide
+information about your operating system and a full Python stack trace.  The
+developers will walk you through obtaining a stack trace if it is necessary.
 
 Contributing
 ============
 
 Like the `Astropy`_ project, ``dust_extinction`` is made both by and for its
-users.  We accept contributions at all levels, spanning the gamut from
-fixing a typo in the documentation to developing a major new feature.
-We welcome contributors who will abide by the `Python Software
-Foundation Code of Conduct
+users.  We accept contributions at all levels, spanning the gamut from fixing a
+typo in the documentation to developing a major new feature. We welcome
+contributors who will abide by the `Python Software Foundation Code of Conduct
 <https://www.python.org/psf/codeofconduct/>`_.
 
 ``dust_extinction`` follows the same workflow and coding guidelines as
-`Astropy`_.  The following pages will help you get started with
-contributing fixes, code, or documentation (no git or GitHub
-experience necessary):
+`Astropy`_.  The following pages will help you get started with contributing
+fixes, code, or documentation (no git or GitHub experience necessary):
 
 * `How to make a code contribution <http://astropy.readthedocs.io/en/stable/development/workflow/development_workflow.html>`_
 
@@ -172,7 +164,6 @@ experience necessary):
 * `Try the development version <http://astropy.readthedocs.io/en/stable/development/workflow/get_devel_version.html>`_
 
 * `Developer Documentation <http://docs.astropy.org/en/latest/#developer-documentation>`_
-
 
 For the complete list of contributors please see the `dust_extinction
 contributors page on Github


### PR DESCRIPTION
Addresses #47.  In conjunction with a companion pull request in the dust_attenuation package.

Docs in dust_extinction focus on fully explaining extinction with minimal attenuation discussion.  Mainly with a pointer to the corresponding discussion in dust_attenuation.