### PR TITLE
Fixes M14 returning 0 when input x starts with 1.0

### DIFF
--- a/dust_extinction/parameter_averages.py
+++ b/dust_extinction/parameter_averages.py
@@ -711,8 +711,8 @@ class M14(BaseExtRvModel):
         #         + bu*((x>xi3)&(x<8.0)) + bf*(x>8.0))
 
         # Final result
-        a = ai*(x < xi1) + av*((x > xi1) & (x < xi3))
-        b = bi*(x < xi1) + bv*((x > xi1) & (x < xi3))
+        a = ai*(x < xi1) + av*((x >= xi1) & (x < xi3))
+        b = bi*(x < xi1) + bv*((x >= xi1) & (x < xi3))
 
         return a + b/Rv
 


### PR DESCRIPTION
Minor issue.  When the input values of x start with 1.0 inverse micron, then M14 returns 0.0 for the 1.0 point.