### PR TITLE
If evaluate member function explicitly called

### DIFF
--- a/dust_extinction/averages.py
+++ b/dust_extinction/averages.py
@@ -60,7 +60,6 @@ class G03_SMCBar(BaseExtAveModel):
         ax.legend(loc='best')
         plt.show()
     """
-
     x_range = x_range_G03
 
     Rv = 2.74

--- a/dust_extinction/helpers.py
+++ b/dust_extinction/helpers.py
@@ -23,6 +23,9 @@ def _get_x_in_wavenumbers(in_x):
     x : floats
         input x values in wavenumbers w/o units
     """
+    # handles the case where x is a scaler
+    in_x = np.atleast_1d(in_x)
+
     # check if in_x is an astropy quantity, if not issue a warning
     if not isinstance(in_x, u.Quantity):
         warnings.warn("x has no units, assuming x units are inverse microns")

--- a/dust_extinction/parameter_averages.py
+++ b/dust_extinction/parameter_averages.py
@@ -96,10 +96,6 @@ class CCM89(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        
-        # converts all input to array 
-        in_x = np.atleast_1d(in_x)
-
         x = _get_x_in_wavenumbers(in_x)
 
         # check that the wavenumbers are within the defined range
@@ -224,10 +220,6 @@ class O94(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-
-        # converts all input to array 
-        in_x = np.atleast_1d(in_x)
-
         x = _get_x_in_wavenumbers(in_x)
 
         # check that the wavenumbers are within the defined range
@@ -354,6 +346,9 @@ class F99(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
+        # just in case someone calls evaluate explicitly
+        Rv = np.atleast_1d(Rv)
+
         # ensure Rv is a single element, not numpy array
         Rv = Rv[0]
 
@@ -482,6 +477,9 @@ class F04(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
+        # just in case someone calls evaluate explicitly
+        Rv = np.atleast_1d(Rv)
+
         # ensure Rv is a single element, not numpy array
         Rv = Rv[0]
 
@@ -835,14 +833,13 @@ class M14(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-
-        # converts all input to array 
-        in_x = np.atleast_1d(in_x)
-
         x = _get_x_in_wavenumbers(in_x)
 
         # check that the wavenumbers are within the defined range
         _test_valid_x_range(x, x_range_M14, 'M14')
+
+        # just in case someone calls evaluate explicitly
+        Rv = np.atleast_1d(Rv)
 
         # ensure Rv is a single element, not numpy array
         Rv = Rv[0]
@@ -1044,14 +1041,13 @@ class G16(BaseExtRvAfAModel):
         ValueError
            Input x values outside of defined range
         """
-        
-        # converts all input to array 
-        in_x = np.atleast_1d(in_x)
-
         x = _get_x_in_wavenumbers(in_x)
 
         # check that the wavenumbers are within the defined range
         _test_valid_x_range(x, x_range_G16, 'G16')
+
+        # just in case someone calls evaluate explicitly
+        RvA = np.atleast_1d(RvA)
 
         # ensure Rv is a single element, not numpy array
         RvA = RvA[0]

--- a/dust_extinction/tests/test_ccm89.py
+++ b/dust_extinction/tests/test_ccm89.py
@@ -160,3 +160,19 @@ def test_extinction_CCM89_extinguish_values_Ebv(Rv):
 
     # test
     np.testing.assert_allclose(tmodel.extinguish(x, Ebv=Ebv), cor_vals)
+
+
+x_vals, axav_vals = get_axav_cor_vals(3.1)
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("test_vals", test_vals)
+def test_extinction_CCM89_single_values(test_vals):
+    x, cor_val = test_vals
+
+    # initialize extinction model
+    tmodel = CCM89()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val)

--- a/dust_extinction/tests/test_f04.py
+++ b/dust_extinction/tests/test_f04.py
@@ -66,12 +66,14 @@ x_vals, axav_vals, tolerance = get_axav_cor_vals()
 test_vals = zip(x_vals, axav_vals, np.full(len(x_vals), tolerance))
 
 
-@pytest.mark.parametrize("test_vals", test_vals)
-def test_extinction_F04_single_values(test_vals):
-    x, cor_val, tolerance = test_vals
+@pytest.mark.parametrize("xtest_vals", test_vals)
+def test_extinction_F04_single_values(xtest_vals):
+    x, cor_val, tolerance = xtest_vals
 
     # initialize extinction model
     tmodel = F04()
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val,
+                               rtol=tolerance)

--- a/dust_extinction/tests/test_f99.py
+++ b/dust_extinction/tests/test_f99.py
@@ -72,3 +72,5 @@ def test_extinction_F99_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val,
+                               rtol=tolerance)

--- a/dust_extinction/tests/test_fm90.py
+++ b/dust_extinction/tests/test_fm90.py
@@ -57,6 +57,25 @@ def test_extinction_FM90_values():
     np.testing.assert_allclose(tmodel(x), cor_vals)
 
 
+x_vals, axav_vals = get_elvebv_cor_vals()
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("xtest_vals", test_vals)
+def test_extinction_FM90_single_values(xtest_vals):
+    x, cor_val = xtest_vals
+
+    # initialize extinction model
+    tmodel = FM90()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val)
+    np.testing.assert_allclose(
+        tmodel.evaluate(x, FM90.C1.default, FM90.C2.default, FM90.C3.default,
+                        FM90.C4.default, FM90.xo.default, FM90.gamma.default),
+        cor_val)
+
+
 def test_FM90_fitting():
 
     # get an observed extinction curve to fit

--- a/dust_extinction/tests/test_g03.py
+++ b/dust_extinction/tests/test_g03.py
@@ -58,6 +58,8 @@ def test_extinction_G03_single_values(tmodel):
     for x, cor_val in zip(tmodel.obsdata_x, tmodel.obsdata_axav):
         np.testing.assert_allclose(tmodel(x), cor_val,
                                    rtol=tmodel.obsdata_tolerance)
+        np.testing.assert_allclose(tmodel.evaluate(x), cor_val,
+                                   rtol=tmodel.obsdata_tolerance)
 
 
 @pytest.mark.parametrize("tmodel", models)

--- a/dust_extinction/tests/test_g16.py
+++ b/dust_extinction/tests/test_g16.py
@@ -85,3 +85,5 @@ def test_extinction_G16_fA_1_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1, 1.0),
+                               cor_val, rtol=tolerance)

--- a/dust_extinction/tests/test_gcc09.py
+++ b/dust_extinction/tests/test_gcc09.py
@@ -75,3 +75,20 @@ def test_extinction_GCC09_values(Rv):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_vals, rtol=1e-5)
+
+
+x_vals, axav_vals = get_axav_cor_vals(3.1)
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("test_vals", test_vals)
+def test_extinction_GCC09_single_values(test_vals):
+    x, cor_val = test_vals
+
+    # initialize extinction model
+    tmodel = GCC09()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val, rtol=1e-5)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1),
+                               cor_val, rtol=1e-5)

--- a/dust_extinction/tests/test_gcc09_ave.py
+++ b/dust_extinction/tests/test_gcc09_ave.py
@@ -54,6 +54,8 @@ def test_extinction_GCC09_single_values():
     for x, cor_val in zip(tmodel.obsdata_x, tmodel.obsdata_axav):
         np.testing.assert_allclose(tmodel(x), cor_val,
                                    rtol=tmodel.obsdata_tolerance)
+        np.testing.assert_allclose(tmodel.evaluate(x), cor_val,
+                                   rtol=tmodel.obsdata_tolerance)
 
 
 def test_extinction_GCC09_extinguish_values_Av():

--- a/dust_extinction/tests/test_ma14.py
+++ b/dust_extinction/tests/test_ma14.py
@@ -69,3 +69,5 @@ def test_extinction_M14_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val,
+                               rtol=tolerance)

--- a/dust_extinction/tests/test_o94.py
+++ b/dust_extinction/tests/test_o94.py
@@ -122,6 +122,22 @@ def test_extinction_O94_values(Rv):
     np.testing.assert_allclose(tmodel(x), cor_vals)
 
 
+x_vals, axav_vals = get_axav_cor_vals(3.1)
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("test_vals", test_vals)
+def test_extinction_O94_single_values(test_vals):
+    x, cor_val = test_vals
+
+    # initialize extinction model
+    tmodel = O94()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val)
+
+
 def test_extinguish_no_av_or_ebv():
     tmodel = O94()
     with pytest.raises(InputParameterError) as exc:

--- a/dust_extinction/tests/test_p92.py
+++ b/dust_extinction/tests/test_p92.py
@@ -66,6 +66,38 @@ def test_extinction_P92_values():
     np.testing.assert_allclose(tmodel(x), cor_vals, rtol=0.25, atol=0.01)
 
 
+x_vals, axav_vals = get_axav_cor_vals()
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("xtest_vals", test_vals)
+def test_extinction_P92_single_values(xtest_vals):
+    x, cor_val = xtest_vals
+
+    # initialize extinction model
+    tmodel = P92()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val,
+                               rtol=0.25, atol=0.01)
+    np.testing.assert_allclose(
+        tmodel.evaluate(
+            x,
+            P92.BKG_amp.default, P92.BKG_lambda.default,
+            P92.BKG_b.default, P92.BKG_n.default,
+            P92.FUV_amp.default, P92.FUV_lambda.default,
+            P92.FUV_b.default, P92.FUV_n.default,
+            P92.NUV_amp.default, P92.NUV_lambda.default,
+            P92.NUV_b.default, P92.NUV_n.default,
+            P92.SIL1_amp.default, P92.SIL1_lambda.default,
+            P92.SIL1_b.default, P92.SIL1_n.default,
+            P92.SIL2_amp.default, P92.SIL2_lambda.default,
+            P92.SIL2_b.default, P92.SIL2_n.default,
+            P92.FIR_amp.default, P92.FIR_lambda.default,
+            P92.FIR_b.default, P92.FIR_n.default),
+        cor_val, rtol=0.25, atol=0.01)
+
+
 def test_P92_fitting():
 
     # get an observed extinction curve to fit

--- a/dust_extinction/tests/test_vcg04.py
+++ b/dust_extinction/tests/test_vcg04.py
@@ -73,3 +73,19 @@ def test_extinction_VCG04_values(Rv):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_vals, rtol=1e-5)
+
+
+x_vals, axav_vals = get_axav_cor_vals(3.1)
+test_vals = zip(x_vals, axav_vals)
+
+
+@pytest.mark.parametrize("test_vals", test_vals)
+def test_extinction_VCG04_single_values(test_vals):
+    x, cor_val = test_vals
+
+    # initialize extinction model
+    tmodel = VCG04()
+
+    # test
+    np.testing.assert_allclose(tmodel(x), cor_val, rtol=1e-5)
+    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val, rtol=1e-5)


### PR DESCRIPTION
Calling evaluate explicitly is not recommend, but it can be.
Tests added.  Solutions added based on @sohamvg partial solution given in PR #109.
Fully addresses issue #108.