### PR TITLE
Fix formatting on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Packaging
 Documentation
 -------------
 
-Using readthedocs: <http://dust-extinction.readthedocs.io>
+Using `readthedocs <http://dust-extinction.readthedocs.io>`_.
 
 In Development!
 ---------------
@@ -95,11 +95,11 @@ process). Some of these contributions may be the most valuable to the project as
 a whole, because you're coming to the project with fresh eyes, so you can see
 the errors and assumptions that seasoned contributors have glossed over.
 
-*This disclaimer was originally written by
+*This disclaimer was originally written by*
 `Adrienne Lowe <https://github.com/adriennefriend>`_ for a
 `PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
 dust_extinction based on its use in the README file for the
-`MetPy project <https://github.com/Unidata/MetPy>`_.*
+`MetPy project <https://github.com/Unidata/MetPy>`_.
 
 License
 -------


### PR DESCRIPTION
Link "readthedocs" and fix formatting for "disclaimer" (link does not render well on GitHub if embedded inside italics).