### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ show-response = 1
 minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
-addopts = -p no:warnings
+addopts = -p no:warnings --doctest-ignore-import-errors
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.