### PR TITLE
Added Rv to G16

### DIFF
--- a/dust_extinction/baseclasses.py
+++ b/dust_extinction/baseclasses.py
@@ -101,6 +101,14 @@ class BaseExtRvAfAModel(BaseExtModel):
     )
     fA = Parameter(description="f_A = mixture coefficent of component A", default=1.0)
 
+    def __init__(self, **kwargs):
+
+        super().__init__(**kwargs)
+
+        # set Rv so that extinguishing by Ebv works
+        # equation 11 in Gordon et al. (2016, ApJ, 826, 104)
+        self.Rv = 1.0 / (self.fA / self.RvA + (1 - self.fA) / 2.74)
+
     @RvA.validator
     def RvA(self, value):
         """

--- a/dust_extinction/tests/test_g16.py
+++ b/dust_extinction/tests/test_g16.py
@@ -62,3 +62,20 @@ def test_extinction_G16_fA_1_single_values(test_vals):
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
     np.testing.assert_allclose(tmodel.evaluate(x, 3.1, 1.0), cor_val, rtol=tolerance)
+
+
+def test_extinction_G16_extinguish_values_Ebv():
+    # get the correct values
+    x, cor_vals, tolerance = get_axav_cor_vals_fA_1()
+
+    # calculate the cor_vals in fractional units
+    Rv = 3.1
+    Ebv = 1.0
+    Av = Ebv * Rv
+    cor_vals = np.power(10.0, -0.4 * (cor_vals * Av))
+
+    # initialize extinction model
+    tmodel = G16(RvA=Rv)
+
+    # test
+    np.testing.assert_allclose(tmodel.extinguish(x, Ebv=Ebv), cor_vals, rtol=1e-3)

--- a/dust_extinction/tests/test_g16.py
+++ b/dust_extinction/tests/test_g16.py
@@ -78,4 +78,4 @@ def test_extinction_G16_extinguish_values_Ebv():
     tmodel = G16(RvA=Rv)
 
     # test
-    np.testing.assert_allclose(tmodel.extinguish(x, Ebv=Ebv), cor_vals, rtol=1e-3)
+    np.testing.assert_allclose(tmodel.extinguish(x, Ebv=Ebv), cor_vals, rtol=tolerance)


### PR DESCRIPTION
Rv needed for G16 to allow for extinguishing inputting E(B-V) for the dust column.

Closes #179.