### PR TITLE
DEP: refactored out an undeclared runtime dependency on setuptools

### DIFF
--- a/dust_extinction/averages.py
+++ b/dust_extinction/averages.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.resources as importlib_resources
 
 import numpy as np
 from scipy.interpolate import interp1d
@@ -845,11 +845,11 @@ class CT06_MWGC(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + "CT06_pixiedust.dat", format="ascii.commented_header"
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / "CT06_pixiedust.dat", format="ascii.commented_header"
+            )
 
         self.obsdata_x = 1.0 / a["wave"].data
         # ext is A(lambda)/A(K)
@@ -947,11 +947,11 @@ class CT06_MWLoc(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + "CT06_pixiedust.dat", format="ascii.commented_header"
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / "CT06_pixiedust.dat", format="ascii.commented_header"
+            )
 
         self.obsdata_x = 1.0 / a["wave"].data
         # ext is A(lambda)/A(K)
@@ -1059,12 +1059,12 @@ class GCC09_MWAvg(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        # GCC09 sigma clipped average of 75 sightlines
-        a = Table.read(data_path + "GCC09_FUSE.dat", format="ascii.commented_header")
-        b = Table.read(data_path + "GCC09_IUE.dat", format="ascii.commented_header")
-        c = Table.read(data_path + "GCC09_PHOT.dat", format="ascii.commented_header")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            # GCC09 sigma clipped average of 75 sightlines
+            a = Table.read(data_path / "GCC09_FUSE.dat", format="ascii.commented_header")
+            b = Table.read(data_path / "GCC09_IUE.dat", format="ascii.commented_header")
+            c = Table.read(data_path / "GCC09_PHOT.dat", format="ascii.commented_header")
 
         # FUSE range
         self.obsdata_x_fuse = a["x"].data
@@ -1213,11 +1213,11 @@ class F11_MWGC(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + "fritz11_galcenter.dat", format="ascii.commented_header"
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / "fritz11_galcenter.dat", format="ascii.commented_header"
+            )
 
         self.obsdata_x = 1.0 / a["wave"].data
         # ext is total extinction to GalCenter
@@ -1325,11 +1325,11 @@ class G21_MWAvg(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        # GCC09 sigma clipped average of 75 sightlines
-        a = Table.read(data_path + "G21_IRS.dat", format="ascii.commented_header")
-        b = Table.read(data_path + "G21_PHOT.dat", format="ascii.commented_header")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            # GCC09 sigma clipped average of 75 sightlines
+            a = Table.read(data_path / "G21_IRS.dat", format="ascii.commented_header")
+            b = Table.read(data_path / "G21_PHOT.dat", format="ascii.commented_header")
 
         # IRS range
         self.obsdata_x_irs = 1.0 / a["wave"].data
@@ -1467,10 +1467,10 @@ class D22_MWAvg(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        # D22 sigma clipped average of 13 diffuse sightlines
-        a = Table.read(data_path + "D22.dat", format="ascii.commented_header")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            # D22 sigma clipped average of 13 diffuse sightlines
+            a = Table.read(data_path / "D22.dat", format="ascii.commented_header")
 
         # Spex data
         self.obsdata_x = 1.0 / a["wavelength[micron]"].data
@@ -1570,10 +1570,10 @@ class G24_SMCAvg(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        # D22 sigma clipped average of 13 diffuse sightlines
-        a = Table.read(data_path + "G24_SMCAvg.dat", format="ascii.commented_header")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            # D22 sigma clipped average of 13 diffuse sightlines
+            a = Table.read(data_path / "G24_SMCAvg.dat", format="ascii.commented_header")
 
         # data
         self.obsdata_x = 1.0 / a["wave"].data
@@ -1693,10 +1693,10 @@ class G24_SMCBumps(BaseExtModel):
     def __init__(self, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        # D22 sigma clipped average of 13 diffuse sightlines
-        a = Table.read(data_path + "G24_SMCBumps.dat", format="ascii.commented_header")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            # D22 sigma clipped average of 13 diffuse sightlines
+            a = Table.read(data_path / "G24_SMCBumps.dat", format="ascii.commented_header")
 
         # data
         self.obsdata_x = 1.0 / a["wave"].data

--- a/dust_extinction/grain_models.py
+++ b/dust_extinction/grain_models.py
@@ -1,4 +1,5 @@
-import pkg_resources
+import importlib.resources as importlib_resources
+
 from scipy.interpolate import interp1d
 import numpy as np
 
@@ -121,14 +122,14 @@ class DBP90(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            data_start=1,
-            header_start=None,
-            format="ascii.basic",
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                data_start=1,
+                header_start=None,
+                format="ascii.basic",
+            )
 
         self.data_x = 1.0 / a["col1"].data
 
@@ -212,17 +213,17 @@ class WD01(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            format="ascii.fixed_width",
-            header_start=None,
-            data_start=41,
-            names=("wave", "albedo", "g", "cext"),
-            col_starts=(0, 10, 18, 25),
-            col_ends=(9, 16, 24, 34),
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                format="ascii.fixed_width",
+                header_start=None,
+                data_start=41,
+                names=("wave", "albedo", "g", "cext"),
+                col_starts=(0, 10, 18, 25),
+                col_ends=(9, 16, 24, 34),
+            )
 
         self.data_x = 1.0 / a["wave"].data
 
@@ -304,17 +305,17 @@ class D03(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            format="ascii.fixed_width",
-            header_start=None,
-            data_start=67,
-            names=("wave", "albedo", "g", "cext"),
-            col_starts=(0, 12, 19, 26),
-            col_ends=(11, 18, 25, 35),
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                format="ascii.fixed_width",
+                header_start=None,
+                data_start=67,
+                names=("wave", "albedo", "g", "cext"),
+                col_starts=(0, 12, 19, 26),
+                col_ends=(11, 18, 25, 35),
+            )
 
         self.data_x = 1.0 / a["wave"].data
 
@@ -392,12 +393,12 @@ class ZDA04(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            format="ascii.basic",
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                format="ascii.basic",
+            )
 
         self.data_x = 1.0 / a["lam[um]"].data
 
@@ -473,14 +474,14 @@ class C11(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            data_start=1,
-            header_start=None,
-            format="ascii.basic",
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                data_start=1,
+                header_start=None,
+                format="ascii.basic",
+            )
 
         self.data_x = 1.0 / a["col1"].data
 
@@ -556,14 +557,14 @@ class J13(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(
-            data_path + filename,
-            data_start=1,
-            header_start=None,
-            format="ascii.basic",
-        )
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(
+                data_path / filename,
+                data_start=1,
+                header_start=None,
+                format="ascii.basic",
+            )
 
         self.data_x = 1.0 / a["col1"].data
 
@@ -639,9 +640,9 @@ class HD23(GMBase):
         self.Rv = self.possnames[modelname][1]
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = getdata(data_path + filename, 2)
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = getdata(data_path / filename, 2)
 
         self.data_x = 1.0 / a[:, 0]
 

--- a/dust_extinction/parameter_averages.py
+++ b/dust_extinction/parameter_averages.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.resources as importlib_resources
 
 import numpy as np
 from scipy import interpolate
@@ -1175,9 +1175,9 @@ class F19(BaseExtRvModel):
     def __init__(self, Rv=3.1, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(data_path + "F19_tabulated.dat", format="ascii")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(data_path / "F19_tabulated.dat", format="ascii")
 
         # compute E(lambda-55)/E(B-55) on the tabulated x points
         self.k_rV_tab_x = a["k_3.02"].data + a["deltak"].data * (Rv - 3.10) * 0.990
@@ -1291,9 +1291,9 @@ class D22(BaseExtRvModel):
     def __init__(self, Rv=3.1, **kwargs):
 
         # get the tabulated information
-        data_path = pkg_resources.resource_filename("dust_extinction", "data/")
-
-        a = Table.read(data_path + "D22_Rv_slope.dat", format="ascii")
+        ref = importlib_resources.files("dust_extinction") / "data"
+        with importlib_resources.as_file(ref) as data_path:
+            a = Table.read(data_path / "D22_Rv_slope.dat", format="ascii")
 
         # setup spline interpolation
         self.spline_rep = interpolate.splrep(a["wavelength[micron]"].data, a["slope"])


### PR DESCRIPTION
I noticed that this package had an undeclared runtime dependency on setuptools (which is where `pkg_resources` is found). I replaced it with standard lib API, following [this migration guide](https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename).