### PR TITLE
updating codecov version

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         tox -e py312-cov
     - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV }}
         fail_ci_if_error: true


### PR DESCRIPTION
Fixing the rate limiting step on codecov.  Seems to just need a version bump on the CI action.