### PR TITLE
Add SpectralUnitsWarning for more targeted warning filters

### DIFF
--- a/docs/dust_extinction/fit_extinction.rst
+++ b/docs/dust_extinction/fit_extinction.rst
@@ -29,6 +29,7 @@ extinction curve for the LMC outside of the LMC2 supershell region
 
     from dust_extinction.averages import G03_LMCAvg
     from dust_extinction.shapes import FM90
+    from dust_extinction.warnings import SpectralUnitsWarning
 
     # get an observed extinction curve to fit
     g03_model = G03_LMCAvg()
@@ -49,9 +50,9 @@ extinction curve for the LMC outside of the LMC2 supershell region
     #   use the initialized model as the starting point
 
     # ignore some warnings
-    #   UserWarning is to avoid the units of x warning
+    #   SpectralUnitsWarning is to avoid the units of x warning
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("ignore", category=SpectralUnitsWarning)
         g03_fit = fit(fm90_init, x[gindxs].value, y[gindxs])
 
     # plot the observed data, initial guess, and final fit
@@ -100,6 +101,7 @@ between data points.
 
    from dust_extinction.averages import GCC09_MWAvg
    from dust_extinction.shapes import P92
+   from dust_extinction.warnings import SpectralUnitsWarning
 
    # get an observed extinction curve to fit
    g09_model = GCC09_MWAvg()
@@ -134,11 +136,11 @@ between data points.
    #   accuracy set to avoid warning the fit may have failed
 
    # ignore some warnings
-   #   UserWarning is to avoid the units of x warning
+   #   SpectralUnitsWarning is to avoid the units of x warning
    #   AstropyWarning ignored to avoid the "fit may have been unsuccessful" warning
    #   fit is fine, but this means the build of the docs fails
    with warnings.catch_warnings():
-       warnings.simplefilter("ignore", category=UserWarning)
+       warnings.simplefilter("ignore", category=SpectralUnitsWarning)
        warnings.simplefilter("ignore", category=AstropyWarning)
        p92_fit = fit(p92_init, x.value, y, weights=1.0 / y_unc)
 

--- a/dust_extinction/helpers.py
+++ b/dust_extinction/helpers.py
@@ -4,6 +4,8 @@ import numpy as np
 from scipy.special import comb
 import astropy.units as u
 
+from .warnings import SpectralUnitsWarning
+
 __all__ = ["_get_x_in_wavenumbers", "_test_valid_x_range", "_smoothstep"]
 
 
@@ -28,7 +30,8 @@ def _get_x_in_wavenumbers(in_x):
     # check if in_x is an astropy quantity, if not issue a warning
     if not isinstance(in_x, u.Quantity):
         warnings.warn(
-            "x has no units, assuming x units are inverse microns", UserWarning
+            "x has no units, assuming x units are inverse microns",
+            SpectralUnitsWarning
         )
 
     # convert to wavenumbers (1/micron) if x input in units

--- a/dust_extinction/tests/test_warnings.py
+++ b/dust_extinction/tests/test_warnings.py
@@ -14,6 +14,7 @@ from .helpers import (
     ave_models,
     grain_models,
 )
+from ..warnings import SpectralUnitsWarning
 
 
 @pytest.mark.parametrize("model", all_models)
@@ -22,7 +23,8 @@ def test_nounits_warning(model):
     x = np.arange(ext.x_range[0], ext.x_range[1], 0.1)
 
     with pytest.warns(
-        UserWarning, match="x has no units, assuming x units are inverse microns"
+        SpectralUnitsWarning,
+        match="x has no units, assuming x units are inverse microns"
     ):
         ext(x)
 

--- a/dust_extinction/warnings.py
+++ b/dust_extinction/warnings.py
@@ -1,0 +1,2 @@
+class SpectralUnitsWarning(UserWarning):
+    pass


### PR DESCRIPTION
This makes it easier for users to disable the unit conversion warnings without also suppressing other unrelated UserWarnings.

This should be a backward-compatible change: since the new warning class subclasses UserWarning, code designed to suppress UserWarnings will still suppress this warning.