### PR TITLE
Move input unit conversion and bounds checking to base class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,16 @@
 1.6.dev (unreleased)
 ================
 
-- none yet
+- Refactor model input unit conversion and wavenumber bounds checking:
+
+  - The models' evaluate methods are no longer meant to be called directly.
+
+  - The BaseExtModel class now overrides the prepare_inputs method so that
+    unit conversion and bounds checking is done prior to calling the subclass'
+    evaluate method. Subclasses are no longer responsible for doing the unit
+    conversion and bounds checking themselves.
+
+  - Use Astropy's built-in input model units handling.
 
 1.5 (2024-08-16)
 ================

--- a/docs/dust_extinction/dev_model.rst
+++ b/docs/dust_extinction/dev_model.rst
@@ -16,7 +16,7 @@ All
 All dust extinction models have at least the following:
 
 * A member variable `x_range` that that define the valid range of wavelengths. These are defined in inverse microns as is common for extinction curve research.
-* A member function `evaluate` that computes the extinction at a given `x` and any model parameter values.  The `x` values are checked to be within the valid `x_range`. The `x` values should have astropy.units.  If they do not, then they are assumed to be in inverse microns and a warning is issued stating such.
+* A member function `evaluate` that computes the extinction at a given `x` and any model parameter values.  The `x` values are checked to be within the valid `x_range`. The `x` values passed to the `evaluate` method have no units; the base class `BaseExtModel` will automatically convert whatever units the user provided to inverse microns prior to calling the `evaulate` method. The `evaluate` method should not be called directly.
 
 All of these classes used in ``dust_extinction`` are based on the 
 `Model <https://docs.astropy.org/en/stable/modeling/>`_ astropy.modeling class.

--- a/dust_extinction/averages.py
+++ b/dust_extinction/averages.py
@@ -5,7 +5,6 @@ from scipy.interpolate import interp1d
 from astropy.table import Table
 from astropy.modeling.models import PowerLaw1D
 
-from .helpers import _get_x_in_wavenumbers, _test_valid_x_range
 from .baseclasses import BaseExtModel
 from .shapes import P92, G21, _curve_F99_method
 
@@ -92,13 +91,14 @@ class RL85_MWGC(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 1e-6
 
-    def evaluate(self, in_x):
+    @classmethod
+    def evaluate(cls, x):
         r"""
         RL85 MWGC function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -114,14 +114,9 @@ class RL85_MWGC(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function using simple linear interpolation
         # avoids negative values of alav that happens with cubic splines
-        f = interp1d(self.obsdata_x, self.obsdata_axav)
+        f = interp1d(cls.obsdata_x, cls.obsdata_axav)
 
         return f(x)
 
@@ -191,13 +186,14 @@ class RRP89_MWGC(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 1e-6
 
-    def evaluate(self, in_x):
+    @classmethod
+    def evaluate(cls, x):
         r"""
         RRP89 MWGC function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -213,14 +209,9 @@ class RRP89_MWGC(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function using simple linear interpolation
         # avoids negative values of alav that happens with cubic splines
-        f = interp1d(self.obsdata_x, self.obsdata_axav)
+        f = interp1d(cls.obsdata_x, cls.obsdata_axav)
 
         return f(x)
 
@@ -293,13 +284,14 @@ class B92_MWAvg(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 6e-3
 
-    def evaluate(self, in_x):
+    @classmethod
+    def evaluate(cls, x):
         """
         B92 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -315,14 +307,8 @@ class B92_MWAvg(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.name)
-
         # define the function allowing for spline interpolation
-        f = interp1d(self.obsdata_x, self.obsdata_axav)
+        f = interp1d(cls.obsdata_x, cls.obsdata_axav)
 
         return f(x)
 
@@ -409,13 +395,13 @@ class G03_SMCBar(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 6e-2
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G03 SMCBar function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -447,7 +433,7 @@ class G03_SMCBar(BaseExtModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             self.Rv,
             C1,
             C2,
@@ -457,8 +443,6 @@ class G03_SMCBar(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -540,13 +524,13 @@ class G03_LMCAvg(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 6e-2
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G03 LMCAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -576,7 +560,7 @@ class G03_LMCAvg(BaseExtModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             self.Rv,
             C1,
             C2,
@@ -586,8 +570,6 @@ class G03_LMCAvg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -672,13 +654,13 @@ class G03_LMC2(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 6e-2
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G03 LMC2 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -708,7 +690,7 @@ class G03_LMC2(BaseExtModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             self.Rv,
             C1,
             C2,
@@ -718,8 +700,6 @@ class G03_LMC2(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -789,13 +769,13 @@ class I05_MWAvg(BaseExtModel):
     # accuracy of the observed data based on published table
     obsdata_tolerance = 1e-6
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         I05 MWAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -811,11 +791,6 @@ class I05_MWAvg(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function allowing for spline interpolation
         f = interp1d(self.obsdata_x, self.obsdata_axav)
 
@@ -891,13 +866,13 @@ class CT06_MWGC(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         CT06 MWGC function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -913,11 +888,6 @@ class CT06_MWGC(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function allowing for spline interpolation
         f = interp1d(self.obsdata_x, self.obsdata_axav)
 
@@ -993,13 +963,13 @@ class CT06_MWLoc(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         CG06 MWLoc function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1015,11 +985,6 @@ class CT06_MWLoc(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function allowing for spline interpolation
         f = interp1d(self.obsdata_x, self.obsdata_axav)
 
@@ -1145,13 +1110,13 @@ class GCC09_MWAvg(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         GCC09_MWAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1167,11 +1132,6 @@ class GCC09_MWAvg(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # P92 parameters fit to the data using uncs as weights
         p92_fit = P92(
             BKG_amp=203.805939127,
@@ -1201,7 +1161,7 @@ class GCC09_MWAvg(BaseExtModel):
         )
 
         # return A(x)/A(V)
-        return p92_fit(in_x)
+        return p92_fit(x)
 
 
 class F11_MWGC(BaseExtModel):
@@ -1275,13 +1235,13 @@ class F11_MWGC(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         F11 MWGC function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1297,11 +1257,6 @@ class F11_MWGC(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # define the function allowing for spline interpolation
         f = interp1d(self.obsdata_x, self.obsdata_axav)
 
@@ -1402,13 +1357,13 @@ class G21_MWAvg(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G21_MWAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1424,11 +1379,6 @@ class G21_MWAvg(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # G21 parameters fit to the data using uncs as weights
         g21_fit = G21(
             scale=0.366,
@@ -1445,7 +1395,7 @@ class G21_MWAvg(BaseExtModel):
 
         # return A(x)/A(V)
         # G21 a full dust_extinction model, hence send in x with units
-        return g21_fit(in_x)
+        return g21_fit(x)
 
 
 class D22_MWAvg(BaseExtModel):
@@ -1526,13 +1476,13 @@ class D22_MWAvg(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         D22_MWAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1548,11 +1498,6 @@ class D22_MWAvg(BaseExtModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # setup the model
         d22_fit = PowerLaw1D(alpha=1.71, amplitude=0.386, x_0=1.0)
 
@@ -1643,13 +1588,13 @@ class G24_SMCAvg(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G24 SMCAvg function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1677,7 +1622,7 @@ class G24_SMCAvg(BaseExtModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             self.Rv,
             C1,
             C2,
@@ -1687,8 +1632,6 @@ class G24_SMCAvg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -1778,13 +1721,13 @@ class G24_SMCBumps(BaseExtModel):
 
         super().__init__(**kwargs)
 
-    def evaluate(self, in_x):
+    def evaluate(self, x):
         """
         G24 SMCBumps function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1812,7 +1755,7 @@ class G24_SMCBumps(BaseExtModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             self.Rv,
             C1,
             C2,
@@ -1822,6 +1765,4 @@ class G24_SMCBumps(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
-            self.x_range,
-            self.__class__.__name__,
         )

--- a/dust_extinction/helpers.py
+++ b/dust_extinction/helpers.py
@@ -2,46 +2,16 @@ import warnings
 
 import numpy as np
 from scipy.special import comb
-import astropy.units as u
 
 from .warnings import SpectralUnitsWarning
 
-__all__ = ["_get_x_in_wavenumbers", "_test_valid_x_range", "_smoothstep"]
+__all__ = ["_warn_no_units", "_test_valid_x_range", "_smoothstep"]
 
 
-def _get_x_in_wavenumbers(in_x):
-    """
-    Convert input x to wavenumber given x has units.
-    Otherwise, assume x is in waveneumbers and issue a warning to this effect.
-
-    Parameters
-    ----------
-    in_x : astropy.quantity or simple floats
-        x values
-
-    Returns
-    -------
-    x : floats
-        input x values in wavenumbers w/o units
-    """
-    # handles the case where x is a scaler
-    in_x = np.atleast_1d(in_x)
-
-    # check if in_x is an astropy quantity, if not issue a warning
-    if not isinstance(in_x, u.Quantity):
-        warnings.warn(
-            "x has no units, assuming x units are inverse microns",
-            SpectralUnitsWarning
-        )
-
-    # convert to wavenumbers (1/micron) if x input in units
-    # otherwise, assume x in appropriate wavenumber units
-    with u.add_enabled_equivalencies(u.spectral()):
-        x_quant = u.Quantity(in_x, 1.0 / u.micron, dtype=np.float64)
-
-    # strip the quantity to avoid needing to add units to all the
-    #    polynomical coefficients
-    return x_quant.value
+def _warn_no_units():
+    warnings.warn(
+        "x has no units, assuming x units are inverse microns", SpectralUnitsWarning
+    )
 
 
 def _test_valid_x_range(x, x_range, outname):

--- a/dust_extinction/parameter_averages.py
+++ b/dust_extinction/parameter_averages.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 from astropy.modeling.models import Drude1D, Polynomial1D, PowerLaw1D
 
 from .baseclasses import BaseExtRvModel, BaseExtRvAfAModel
-from .helpers import _get_x_in_wavenumbers, _test_valid_x_range, _smoothstep
+from .helpers import _smoothstep
 from .averages import G03_SMCBar
 from .shapes import _curve_F99_method, _modified_drude, FM90
 
@@ -88,13 +88,13 @@ class CCM89(BaseExtRvModel):
     x_range = x_range_CCM89
 
     @staticmethod
-    def evaluate(in_x, Rv):
+    def evaluate(x, Rv):
         """
         CCM89 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -110,15 +110,9 @@ class CCM89(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_CCM89, "CCM89")
-
         # setup the a & b coefficient vectors
-        n_x = len(x)
-        a = np.zeros(n_x)
-        b = np.zeros(n_x)
+        a = np.zeros(x.shape)
+        b = np.zeros(x.shape)
 
         # define the ranges
         ir_indxs = np.where(np.logical_and(0.3 <= x, x < 1.1))
@@ -224,13 +218,13 @@ class O94(BaseExtRvModel):
     x_range = x_range_O94
 
     @staticmethod
-    def evaluate(in_x, Rv):
+    def evaluate(x, Rv):
         """
         O94 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -246,15 +240,9 @@ class O94(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_O94, "O94")
-
         # setup the a & b coefficient vectors
-        n_x = len(x)
-        a = np.zeros(n_x)
-        b = np.zeros(n_x)
+        a = np.zeros(x.shape)
+        b = np.zeros(x.shape)
 
         # define the ranges
         ir_indxs = np.where(np.logical_and(0.3 <= x, x < 1.1))
@@ -362,13 +350,14 @@ class F99(BaseExtRvModel):
     Rv_range = [2.0, 6.0]
     x_range = x_range_F99
 
-    def evaluate(self, in_x, Rv):
+    @staticmethod
+    def evaluate(x, Rv):
         """
         F99 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -430,7 +419,7 @@ class F99(BaseExtRvModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             Rv,
             C1,
             C2,
@@ -440,8 +429,6 @@ class F99(BaseExtRvModel):
             gamma,
             optnir_axav_x,
             optnir_axebv_y / Rv,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -511,13 +498,14 @@ class F04(BaseExtRvModel):
     Rv_range = [2.0, 6.0]
     x_range = x_range_F04
 
-    def evaluate(self, in_x, Rv):
+    @staticmethod
+    def evaluate(x, Rv):
         """
         F04 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -578,7 +566,7 @@ class F04(BaseExtRvModel):
 
         # return A(x)/A(V)
         return _curve_F99_method(
-            in_x,
+            x,
             Rv,
             C1,
             C2,
@@ -588,8 +576,6 @@ class F04(BaseExtRvModel):
             gamma,
             optnir_axav_x,
             optnir_axebv_y / Rv,
-            self.x_range,
-            self.__class__.__name__,
         )
 
 
@@ -657,13 +643,13 @@ class VCG04(BaseExtRvModel):
     x_range = x_range_VCG04
 
     @staticmethod
-    def evaluate(in_x, Rv):
+    def evaluate(x, Rv):
         """
         VCG04 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
            internally wavenumbers are used
@@ -678,17 +664,9 @@ class VCG04(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        # convert to wavenumbers (1/micron) if x input in units
-        # otherwise, assume x in appropriate wavenumber units
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_VCG04, "VCG04")
-
         # setup the a & b coefficient vectors
-        n_x = len(x)
-        a = np.zeros(n_x)
-        b = np.zeros(n_x)
+        a = np.zeros(x.shape)
+        b = np.zeros(x.shape)
 
         # define the ranges
         nuv_indxs = np.where(np.logical_and(3.3 <= x, x <= 8.0))
@@ -777,13 +755,13 @@ class GCC09(BaseExtRvModel):
     x_range = x_range_GCC09
 
     @staticmethod
-    def evaluate(in_x, Rv):
+    def evaluate(x, Rv):
         """
         GCC09 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -799,17 +777,9 @@ class GCC09(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        # convert to wavenumbers (1/micron) if x input in units
-        # otherwise, assume x in appropriate wavenumber units
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_GCC09, "GCC09")
-
         # setup the a & b coefficient vectors
-        n_x = len(x)
-        a = np.zeros(n_x)
-        b = np.zeros(n_x)
+        a = np.zeros(x.shape)
+        b = np.zeros(x.shape)
 
         # define the ranges
         nuv_indxs = np.where(np.logical_and(3.3 <= x, x <= 11.0))
@@ -914,13 +884,14 @@ class M14(BaseExtRvModel):
     Rv_range = [2.0, 6.0]
     x_range = x_range_M14
 
-    def evaluate(self, in_x, Rv):
+    @staticmethod
+    def evaluate(x, Rv):
         """
         M14 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -936,11 +907,6 @@ class M14(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 
@@ -1157,13 +1123,13 @@ class G16(BaseExtRvAfAModel):
     x_range = x_range_G16
 
     @staticmethod
-    def evaluate(in_x, RvA, fA):
+    def evaluate(x, RvA, fA):
         """
         G16 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1179,11 +1145,6 @@ class G16(BaseExtRvAfAModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, x_range_G16, "G16")
-
         # just in case someone calls evaluate explicitly
         RvA = np.atleast_1d(RvA)
 
@@ -1287,13 +1248,13 @@ class F19(BaseExtRvModel):
 
         super().__init__(Rv, **kwargs)
 
-    def evaluate(self, in_x, Rv):
+    def evaluate(self, x, Rv):
         """
         F19 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1309,13 +1270,6 @@ class F19(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        # convert to wavenumbers (1/micron) if x input in units
-        # otherwise, assume x in appropriate wavenumber units
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 
@@ -1400,13 +1354,13 @@ class D22(BaseExtRvModel):
 
         super().__init__(Rv, **kwargs)
 
-    def evaluate(self, in_x, Rv):
+    def evaluate(self, x, Rv):
         """
         D22 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1422,13 +1376,6 @@ class D22(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        # convert to wavenumbers (1/micron) if x input in units
-        # otherwise, assume x in appropriate wavenumber units
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, self.__class__.__name__)
-
         # just in case someone calls evaluate explicitly
         Rv = np.atleast_1d(Rv)
 
@@ -1499,13 +1446,13 @@ class G23(BaseExtRvModel):
     Rv_range = [2.3, 5.6]
     x_range = x_range_G23
 
-    def evaluate(self, in_x, Rv):
+    def evaluate(self, x, Rv):
         """
         G23 function
 
         Parameters
         ----------
-        in_x: float
+        x: float
            expects either x in units of wavelengths or frequency
            or assumes wavelengths in wavenumbers [1/micron]
 
@@ -1521,15 +1468,9 @@ class G23(BaseExtRvModel):
         ValueError
            Input x values outside of defined range
         """
-        x = _get_x_in_wavenumbers(in_x)
-
-        # check that the wavenumbers are within the defined range
-        _test_valid_x_range(x, self.x_range, "G23")
-
         # setup the a & b coefficient vectors
-        n_x = len(x)
-        self.a = np.zeros(n_x)
-        self.b = np.zeros(n_x)
+        self.a = np.zeros(x.shape)
+        self.b = np.zeros(x.shape)
 
         # define the ranges
         ir_indxs = np.where(np.logical_and(1.0 / 35.0 <= x, x < 1.0 / 1.0))

--- a/dust_extinction/tests/test_ccm89.py
+++ b/dust_extinction/tests/test_ccm89.py
@@ -230,4 +230,3 @@ def test_extinction_CCM89_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val)
-    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val)

--- a/dust_extinction/tests/test_corvals.py
+++ b/dust_extinction/tests/test_corvals.py
@@ -108,4 +108,3 @@ def test_corvals(model_class, test_parameters):
         # test single value evalutation
         for x, y in zip(x_vals, y_vals):
             np.testing.assert_allclose(tmodel(x), y, atol=tol)
-            np.testing.assert_allclose(tmodel.evaluate(x, Rv), y, atol=tol)

--- a/dust_extinction/tests/test_corvals_aves.py
+++ b/dust_extinction/tests/test_corvals_aves.py
@@ -19,7 +19,6 @@ def test_corvals(model_class):
     # test single value evalutation
     for x, y in zip(x_vals, y_vals):
         np.testing.assert_allclose(tmodel(x), y, rtol=tol)
-        np.testing.assert_allclose(tmodel.evaluate(x), y, rtol=tol)
 
 
 @pytest.mark.parametrize("model_class", ave_models)

--- a/dust_extinction/tests/test_fm90.py
+++ b/dust_extinction/tests/test_fm90.py
@@ -48,18 +48,6 @@ def test_extinction_FM90_single_values(xtest_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val)
-    np.testing.assert_allclose(
-        tmodel.evaluate(
-            x,
-            FM90.C1.default,
-            FM90.C2.default,
-            FM90.C3.default,
-            FM90.C4.default,
-            FM90.xo.default,
-            FM90.gamma.default,
-        ),
-        cor_val,
-    )
 
 
 def test_FM90_fitting():

--- a/dust_extinction/tests/test_g16.py
+++ b/dust_extinction/tests/test_g16.py
@@ -61,7 +61,6 @@ def test_extinction_G16_fA_1_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=tolerance)
-    np.testing.assert_allclose(tmodel.evaluate(x, 3.1, 1.0), cor_val, rtol=tolerance)
 
 
 def test_extinction_G16_extinguish_values_Ebv():

--- a/dust_extinction/tests/test_gcc09.py
+++ b/dust_extinction/tests/test_gcc09.py
@@ -130,4 +130,3 @@ def test_extinction_GCC09_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=1e-5)
-    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val, rtol=1e-5)

--- a/dust_extinction/tests/test_p92.py
+++ b/dust_extinction/tests/test_p92.py
@@ -112,38 +112,6 @@ def test_extinction_P92_single_values(xtest_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=0.25, atol=0.01)
-    np.testing.assert_allclose(
-        tmodel.evaluate(
-            x,
-            P92.BKG_amp.default,
-            P92.BKG_lambda.default,
-            P92.BKG_b.default,
-            P92.BKG_n.default,
-            P92.FUV_amp.default,
-            P92.FUV_lambda.default,
-            P92.FUV_b.default,
-            P92.FUV_n.default,
-            P92.NUV_amp.default,
-            P92.NUV_lambda.default,
-            P92.NUV_b.default,
-            P92.NUV_n.default,
-            P92.SIL1_amp.default,
-            P92.SIL1_lambda.default,
-            P92.SIL1_b.default,
-            P92.SIL1_n.default,
-            P92.SIL2_amp.default,
-            P92.SIL2_lambda.default,
-            P92.SIL2_b.default,
-            P92.SIL2_n.default,
-            P92.FIR_amp.default,
-            P92.FIR_lambda.default,
-            P92.FIR_b.default,
-            P92.FIR_n.default,
-        ),
-        cor_val,
-        rtol=0.25,
-        atol=0.01,
-    )
 
 
 @pytest.mark.skip(reason="failing due to an issue with the fitting")

--- a/dust_extinction/tests/test_vcg04.py
+++ b/dust_extinction/tests/test_vcg04.py
@@ -70,4 +70,3 @@ def test_extinction_VCG04_single_values(test_vals):
 
     # test
     np.testing.assert_allclose(tmodel(x), cor_val, rtol=1e-5)
-    np.testing.assert_allclose(tmodel.evaluate(x, 3.1), cor_val, rtol=1e-5)


### PR DESCRIPTION
There are two goals of this PR:

1. Self-document what units these models expect by advertising the models in standard astropy.modeling.Model metadata.
2. Eliminate input preparation code that was previously duplicated in every dust extinction model subclass.