### PR TITLE
adding option for FM90_B3 to FM99_method

### DIFF
--- a/dust_extinction/shapes.py
+++ b/dust_extinction/shapes.py
@@ -97,7 +97,7 @@ def _curve_F99_method(
 
     # FM90 model and values
     if fm90_version == "B3":
-        fm90_model = FM90(C1=C1, C2=C2, B3=bump_param, C4=C4, xo=xo, gamma=gamma)
+        fm90_model = FM90_B3(C1=C1, C2=C2, B3=bump_param, C4=C4, xo=xo, gamma=gamma)
     else:
         fm90_model = FM90(C1=C1, C2=C2, C3=bump_param, C4=C4, xo=xo, gamma=gamma)
     # evaluate model and get results in A(x)/A(V)

--- a/dust_extinction/shapes.py
+++ b/dust_extinction/shapes.py
@@ -17,12 +17,13 @@ def _curve_F99_method(
     Rv,
     C1,
     C2,
-    C3,
+    bump_param,
     C4,
     xo,
     gamma,
     optnir_axav_x,
     optnir_axav_y,
+    fm90_version="C3",
 ):
     """
     Function to return extinction using F99 method
@@ -44,8 +45,9 @@ def _curve_F99_method(
     C2: float
         slope of liner term: FM90 parameter
 
-    C3: float
-        amplitude of "2175 A" bump: FM90 parameter
+    bump_param: float
+        C3 for fm90_version = "C3"
+        B3 for fm90_version = "B3"
 
     C4: float
         amplitude of FUV rise: FM90 parameter
@@ -61,6 +63,9 @@ def _curve_F99_method(
 
     optnir_axav_y: float array
         vector of y values for optical/NIR A(x)/A(V) curve
+
+    fm90_version: str
+        "C3" for standard FM90, "B3" for FM90_B3 for true bump amplitude version
 
     Returns
     -------
@@ -91,7 +96,10 @@ def _curve_F99_method(
         xuv = x_splineval_uv
 
     # FM90 model and values
-    fm90_model = FM90(C1=C1, C2=C2, C3=C3, C4=C4, xo=xo, gamma=gamma)
+    if fm90_version == "B3":
+        fm90_model = FM90(C1=C1, C2=C2, B3=bump_param, C4=C4, xo=xo, gamma=gamma)
+    else:
+        fm90_model = FM90(C1=C1, C2=C2, C3=bump_param, C4=C4, xo=xo, gamma=gamma)
     # evaluate model and get results in A(x)/A(V)
     axav_fm90 = fm90_model(xuv / u.micron) / Rv + 1.0
 

--- a/dust_extinction/tests/test_corvals.py
+++ b/dust_extinction/tests/test_corvals.py
@@ -60,7 +60,7 @@ models_corvals = {
         "atol": 4e-3,
         # from Fitzpatrick (1999) Table 3
         # keep optical from Fitzpatrick (1999),
-        # replce NIR with Fitzpatrick (2004) function for Rv=3.1:
+        # replace NIR with Fitzpatrick (2004) function for Rv=3.1:
         # (0.63*3.1 - 0.84)*x**1.84
     },
     M14: {


### PR DESCRIPTION
Useful for measure_extinction.modeldata.  Allows fitting for the amplitude of the 2175 A bump (B3) instead of the "strength" C3.