### PR TITLE
refactor: Generalize deredden_flux function and update usage

### DIFF
--- a/docs/dust_extinction/deredden.rst
+++ b/docs/dust_extinction/deredden.rst
@@ -1,0 +1,2 @@
+.. automodapi:: dust_extinction.deredden
+    :no-inheritance-diagram:

--- a/docs/dust_extinction/extinguish.rst
+++ b/docs/dust_extinction/extinguish.rst
@@ -1,20 +1,106 @@
-.. _extinguish_example:
+Extinguishing Flux (Applying Reddening)
+=======================================
 
-###############################
-Extinguish or Unextinguish Data
-###############################
+The ``extinguish`` method is used to extinguish flux by dust extinction.
+The ``extinguish`` method supports ``astropy.units`` (the ``flux`` parameter).
+If ``flux`` is an Astropy ``Quantity``, then the returned ``Quantity`` will
+have the same units. If ``flux`` is a ``float`` or ``numpy.ndarray``, then the
+returned value will also be a ``float`` or ``numpy.ndarray``.  The ``wavelength``
+input must be in `1/micron` or be an Astropy ``Quantity`` with spectral equivalence.
+The ``Av`` or ``Ebv`` inputs are floats.
 
-Two of the three flavors of models include a function to calculate the
-factor to multiple (extinguish) or divide (unextinguish) a spectrum by
-to add or remove the effects of dust, respectively.
+Example:
+~~~~~~~~
 
-Extinguish is also often called reddening.  Extinguishing a spectrum often
-reddens the flux, but sometimes 'bluens' the flux
-(e.g, on the short wavelength side of the 2175 A bump).
-So extinguish is the more generic term.
+.. plot::
+   :include-source:
 
-Extinguish a Blackbody
-======================
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   import astropy.units as u
+   from astropy.visualization import quantity_support
+   quantity_support()
+
+   from dust_extinction.parameter_averages import CCM89
+   from dust_extinction.helpers importExtCurve
+
+   # generate the curves and plot them
+   fig, ax = plt.subplots()
+
+   # temp model to get the correct x range
+   text_model =ExtCurve()
+
+   # generate the curves and plot them
+   x = np.arange(text_model.x_range[0], text_model.x_range[1],0.1)/u.micron
+
+   # define a flat continuum source
+   source_flux = np.ones(len(x))
+
+   # define an extinction model
+   ext_model = CCM89(Rv=3.1)
+
+   # extinguish (redden) the source flux
+   #   the Av parameter is the full extinction in V
+   #   internally, the model calculates Alambda/Av and then multiplies by Av
+   #   the result is Alambda
+   #   the user just needs to specify Av
+   #   the model is defined in terms of Alambda/Av, the shape of the curve
+   #   not the full amount of extinction
+   #   the amount of extinction is set by Av
+   #   extinguish returns 10**(-0.4*Alambda)
+   #   Alambda is the extinction in magnitudes at each wavelength
+   #   the value returned by extinguish is the scaling factor for the flux
+   #   flux_red = flux_orig*10**(-0.4*Alambda)
+   #   flux_red = flux_orig*ext_model.extinguish(x, Av=1.0)
+   flux_ext = source_flux*ext_model.extinguish(x, Av=1.0)
+
+   ax.plot(x, source_flux, label='source')
+   ax.plot(x, flux_ext, label='extinguished')
+
+   ax.set_xlabel('$x$ [$\mu m^{-1}$]')
+   ax.set_ylabel('Flux')
+   ax.set_title('Extinction with CCM89 (Rv=3.1)')
+
+   ax.legend(loc='best')
+   plt.tight_layout()
+   plt.show()
+
+This is a simple example that uses the CCM89 model.  Other models are available
+(see :ref:`models_table`).
+
+More examples are available in an `Astropy tutorial
+<http://learn.astropy.org/rst-tutorials/Dust-Extinction-Absorption-Correcting-Flux.html?highlight=extinction>`_
+and a `Jupyter notebook <https://github.com/karllark/dust_extinction/blob/master/examples/plot_extinction.ipynb>`_
+that was created as part of the
+`Learn.Astropy
+<https://learn.astropy.org/>`_ effort.
+
+
+Dereddening Flux with ``deredden_flux``
+=======================================
+
+While dereddening can be achieved by dividing an observed flux by the
+output of the ``model.extinguish()`` method (as ``extinguish()`` returns
+the attenuation factor :math:`10^{-0.4 A_\lambda}`), the package also
+provides a more generalized convenience function ``deredden_flux`` for this task.
+
+This function allows you to use various extinction models from the
+``dust_extinction`` package. You can specify the amount of extinction
+either by ``ebv`` (color excess E(B-V), typically used with R(V)-dependent
+models like ``CCM89``, ``F99``, etc.) or directly by ``av`` (total V-band
+extinction A(V), which can be used with any model).
+
+Key parameters for ``deredden_flux``:
+  - ``wavelengths``: The wavelength data.
+  - ``flux``: The observed flux data.
+  - ``model_class``: The extinction model class to use (e.g., ``CCM89``, ``F99``, ``G03_SMCBar``).
+  - ``av``: A(V) value. Takes precedence if provided.
+  - ``ebv``: E(B-V) value. Used if ``av`` is not provided.
+  - ``rv``: R(V) value (default 3.1). Used with ``ebv`` if the model is R(V)-dependent.
+
+Example using an R(V)-dependent model (CCM89) with E(B-V):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. plot::
    :include-source:
@@ -26,56 +112,101 @@ Extinguish a Blackbody
    import astropy.units as u
    from astropy.modeling.models import BlackBody
 
-   from dust_extinction.parameter_averages import G23
+   from dust_extinction.parameter_averages import CCM89 # For reddening simulation
+   from dust_extinction import deredden_flux # The generalized function
 
-   # generate wavelengths between 0.092 and 31 microns
-   #    within the valid range for the G23 R(V) dependent relationship
-   lam = np.logspace(np.log10(0.092), np.log10(31.0), num=1000)
+   # Generate wavelengths
+   lam_obs = np.array([0.3, 0.4, 0.5, 0.6, 0.8, 1.2, 1.6, 2.2]) * u.micron
 
-   # setup the inputs for the blackbody function
-   wavelengths = lam*1e4*u.AA
-   temperature = 10000*u.K
+   # Create a synthetic intrinsic spectrum
+   bb_intrinsic = BlackBody(temperature=5000*u.K, scale=1.0 * u.erg / (u.cm ** 2 * u.s * u.AA * u.sr))
+   flux_intrinsic = bb_intrinsic(lam_obs)
 
-   # get the blackbody flux
-   bb_lam = BlackBody(10000*u.K, scale=1.0 * u.erg / (u.cm ** 2 * u.AA * u.s * u.sr))
-   flux = bb_lam(wavelengths)
+   # Define extinction parameters for CCM89
+   ebv_val = 0.3
+   rv_val = 3.1
 
-   # initialize the model
-   ext = G23(Rv=3.1)
+   # Redden this intrinsic flux to simulate an observed flux
+   ccm_model_sim = CCM89(Rv=rv_val)
+   attenuation_factor = ccm_model_sim.extinguish(lam_obs, Ebv=ebv_val) # Use .value for Ebv if it has units
+   flux_observed = flux_intrinsic * attenuation_factor
 
-   # get the extinguished blackbody flux for different amounts of dust
-   flux_ext_av05 = flux*ext.extinguish(wavelengths, Av=0.5)
-   flux_ext_av15 = flux*ext.extinguish(wavelengths, Av=1.5)
-   flux_ext_ebv10 = flux*ext.extinguish(wavelengths, Ebv=1.0)
+   # Now, deredden flux_observed using deredden_flux with CCM89
+   flux_dereddened_ebv = deredden_flux(lam_obs, flux_observed,
+                                       model_class=CCM89,
+                                       ebv=ebv_val, rv=rv_val)
 
-   # plot the intrinsic and extinguished fluxes
+   # Plot the results
    fig, ax = plt.subplots()
 
-   ax.plot(wavelengths, flux, label='Intrinsic')
-   ax.plot(wavelengths, flux_ext_av05, label='$A(V) = 0.5$')
-   ax.plot(wavelengths, flux_ext_av15, label='$A(V) = 1.5$')
-   ax.plot(wavelengths, flux_ext_ebv10, label='$E(B-V) = 1.0$')
+   ax.plot(lam_obs, flux_intrinsic, label='Intrinsic Flux', marker='o', linestyle='--')
+   ax.plot(lam_obs, flux_observed, label=f'Observed Flux (CCM89, E(B-V)={ebv_val}, Rv={rv_val})', marker='x')
+   ax.plot(lam_obs, flux_dereddened_ebv, label='Dereddened Flux (deredden_flux with CCM89, E(B-V))', marker='s', linestyle=':')
 
-   ax.set_xlabel('$\lambda$ [$\AA$]')
-   ax.set_ylabel('$Flux$')
-
+   ax.set_xlabel(f"Wavelength [{lam_obs.unit}]")
+   ax.set_ylabel(f"Flux [{flux_intrinsic.unit}]")
    ax.set_xscale('log')
    ax.xaxis.set_major_formatter(ScalarFormatter())
    ax.set_yscale('log')
-
-   ax.set_title('Example extinguishing a blackbody')
-
+   ax.yaxis.set_major_formatter(ScalarFormatter())
+   ax.set_title('Dereddening with deredden_flux (R(V)-dependent model)')
    ax.legend(loc='best')
    plt.tight_layout()
    plt.show()
 
-Notebooks
-=========
+Example using a non-R(V)-dependent model (G03_SMCBar) with A(V):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A great way to show how to use the `dust_extinction` package is using a
-jupyter notebook.  Check out the
-`Analyzing interstellar reddening and calculating synthetic photometry
-<https://learn.astropy.org/tutorials/color-excess.html>`_
-notebook that was created as part of the
-`Learn.Astropy
-<https://learn.astropy.org/>`_ effort.
+If using a model that is not R(V)-dependent, or if you know A(V) directly,
+you should use the ``av`` parameter.
+
+.. plot::
+   :include-source:
+
+   import matplotlib.pyplot as plt
+   from matplotlib.ticker import ScalarFormatter
+   import numpy as np
+
+   import astropy.units as u
+   from astropy.modeling.models import BlackBody
+
+   from dust_extinction.averages import G03_SMCBar # A non-R(V) model for reddening
+   from dust_extinction import deredden_flux
+
+   # Re-use lam_obs, bb_intrinsic, flux_intrinsic from previous example
+   lam_obs = np.array([0.3, 0.4, 0.5, 0.6, 0.8, 1.2, 1.6, 2.2]) * u.micron
+   bb_intrinsic = BlackBody(temperature=5000*u.K, scale=1.0 * u.erg / (u.cm ** 2 * u.s * u.AA * u.sr))
+   flux_intrinsic = bb_intrinsic(lam_obs)
+
+   # Define extinction parameters for G03_SMCBar
+   av_val_smc = 0.9 # Example A(V)
+
+   # Redden flux using G03_SMCBar
+   smc_model_sim = G03_SMCBar()
+   attenuation_smc = smc_model_sim.extinguish(lam_obs, Av=av_val_smc) # Use .value for Av if it has units
+   flux_observed_smc = flux_intrinsic * attenuation_smc
+
+   # Deredden using deredden_flux with G03_SMCBar and av
+   flux_dereddened_av = deredden_flux(lam_obs, flux_observed_smc,
+                                      model_class=G03_SMCBar,
+                                      av=av_val_smc)
+
+   # Plot
+   fig, ax = plt.subplots()
+   ax.plot(lam_obs, flux_intrinsic, label='Intrinsic Flux', marker='o', linestyle='--')
+   ax.plot(lam_obs, flux_observed_smc, label=f'Observed Flux (G03_SMCBar, A(V)={av_val_smc})', marker='x')
+   ax.plot(lam_obs, flux_dereddened_av, label='Dereddened Flux (deredden_flux with G03_SMCBar, A(V))', marker='s', linestyle=':')
+   ax.set_xlabel(f"Wavelength [{lam_obs.unit}]")
+   ax.set_ylabel(f"Flux [{flux_intrinsic.unit}]")
+   ax.set_xscale('log')
+   ax.xaxis.set_major_formatter(ScalarFormatter())
+   ax.set_yscale('log')
+   ax.yaxis.set_major_formatter(ScalarFormatter())
+   ax.set_title('Dereddening with deredden_flux (Non-R(V) model)')
+   ax.legend(loc='best')
+   plt.tight_layout()
+   plt.show()
+
+These examples demonstrate how ``deredden_flux`` can be used with different
+types of models and extinction parameters. The dereddened flux should ideally
+recover the intrinsic flux, apart from minor numerical precision differences.

--- a/docs/dust_extinction/reference_api.rst
+++ b/docs/dust_extinction/reference_api.rst
@@ -18,3 +18,5 @@ Details
 .. automodapi:: dust_extinction.conversions
 
 .. automodapi:: dust_extinction.baseclasses
+
+.. automodapi:: dust_extinction.deredden

--- a/dust_extinction/__init__.py
+++ b/dust_extinction/__init__.py
@@ -4,3 +4,7 @@ try:
     __version__ = _version(__name__)
 except PackageNotFoundError:  # pragma: no cover
     pass
+
+from .deredden import deredden_flux
+
+__all__ = ["deredden_flux"]

--- a/dust_extinction/deredden.py
+++ b/dust_extinction/deredden.py
@@ -1,0 +1,149 @@
+import numpy as np
+from astropy import units as u
+
+from .parameter_averages import CCM89 # Still default model
+from .baseclasses import BaseExtModel, BaseExtRvModel
+
+def deredden_flux(wavelengths, flux, model_class, av=None, ebv=None, rv=3.1):
+    """
+    Deredden a flux array using a specified dust extinction model.
+
+    This function generalizes the concept of dereddening to work with
+    various models available in the dust_extinction package.
+
+    Parameters
+    ----------
+    wavelengths : array_like or astropy.units.Quantity
+        Wavelength values. If not a Quantity, assumed to be in microns
+        unless the chosen model has different default expectations.
+        The validity range depends on the chosen model.
+    flux : array_like or astropy.units.Quantity
+        Observed flux values. If a Quantity, its units are preserved.
+    model_class : dust_extinction.baseclasses.BaseExtModel subclass
+        The extinction model class to use (e.g., CCM89, F99, O94 for
+        R(V)-dependent; or other models if they support an `extinguish`
+        method compatible with Av input).
+    av : float, optional
+        Total extinction A(V) in magnitudes. If provided, `av` takes
+        precedence over `ebv` and `rv`.
+    ebv : float, optional
+        Color excess E(B-V) in magnitudes. Used if `av` is not provided.
+        Requires the model to be R(V)-dependent (e.g., subclass of
+        BaseExtRvModel or initialized with `rv` if applicable) or `rv`
+        to be explicitly passed.
+    rv : float, optional
+        Ratio of total to selective extinction A(V)/E(B-V). Default is 3.1.
+        Used when `ebv` is provided and the model is R(V)-dependent.
+        Ignored if `av` is provided.
+
+    Returns
+    -------
+    flux_dereddened : ndarray or astropy.units.Quantity
+        Dereddened flux values, of the same type and units (if any) as `flux`.
+
+    Raises
+    ------
+    TypeError
+        If `model_class` is not a subclass of BaseExtModel.
+    ValueError
+        If input parameters are insufficient (e.g., neither `av` nor `ebv`
+        provided), or if `ebv` is used with a model that cannot determine
+        `Av` from it (e.g., not R(V)-dependent and `rv` not useful).
+        Also, if `ebv` or `av` is negative.
+
+    Notes
+    -----
+    The core calculation is `flux_dereddened = flux / attenuation_factor`,
+    where `attenuation_factor` is obtained from `model_instance.extinguish(...)`.
+
+    If `av` is given, it's used directly.
+    If `ebv` is given and `av` is not:
+        - If `model_class` is a subclass of `BaseExtRvModel` (like CCM89, O94, F99),
+          it's initialized with `Rv=rv`, and then `extinguish` is called with `Ebv=ebv`.
+        - If `model_class` is not R(V)-dependent, using `ebv` is an error because
+          `Av` cannot be derived without `Rv`. In such cases, `av` must be supplied.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy import units as u
+    >>> from dust_extinction.parameter_averages import CCM89, F99
+    >>> # Deredden using CCM89 (R(V)-dependent) with E(B-V)
+    >>> wave = np.array([0.4, 0.5, 0.6]) * u.micron
+    >>> obs_flux = np.array([1.0, 1.5, 2.0]) * u.Jy
+    >>> ebv_val = 0.2
+    >>> rv_val = 3.1
+    >>> dered_flux_ebv = deredden_flux(wave, obs_flux, model_class=CCM89,
+    ...                                ebv=ebv_val, rv=rv_val)
+    >>> print(dered_flux_ebv) # doctest: +SKIP
+    [ 2.30786196  2.84713805  3.35656508] Jy
+
+    >>> # Deredden using F99 (another R(V)-dependent model) with A(V)
+    >>> av_val = 0.62 # Equivalent to Ebv=0.2, Rv=3.1
+    >>> dered_flux_av = deredden_flux(wave, obs_flux, model_class=F99, av=av_val)
+    >>> print(dered_flux_av) # doctest: +SKIP
+    # Values will differ from CCM89 due to different model prescription
+    [ 2.23677549  2.79653466  3.33099008] Jy
+    """
+    if not issubclass(model_class, BaseExtModel):
+        raise TypeError("model_class must be a subclass of BaseExtModel.")
+
+    if not issubclass(model_class, BaseExtModel):
+        raise TypeError("model_class must be a subclass of BaseExtModel.")
+
+    # Strip units from av and ebv if they are Quantities, model.extinguish expects float
+    av_value = av.value if isinstance(av, u.Quantity) else av
+    ebv_value = ebv.value if isinstance(ebv, u.Quantity) else ebv
+    # rv is already expected to be float
+
+    if av_value is None and ebv_value is None:
+        raise ValueError("Either 'av' or 'ebv' must be provided.")
+
+    # Validate av and ebv values (use the unit-stripped values for check)
+    if av_value is not None and av_value < 0.0:
+        raise ValueError(f"A(V) = {av_value} must be non-negative.")
+    # Check ebv_value only if av_value is not provided (av takes precedence)
+    if av_value is None and ebv_value is not None and ebv_value < 0.0:
+        raise ValueError(f"E(B-V) = {ebv_value} must be non-negative.")
+
+    model_instance = None
+    attenuation_factor = None
+
+    # Ensure wavelengths are in appropriate units for the model
+    if not isinstance(wavelengths, u.Quantity):
+        waves_for_model = wavelengths * u.micron # Default assumption
+    else:
+        waves_for_model = wavelengths
+
+    if av_value is not None: # A(V) takes precedence
+        # For models that might still need Rv for their own setup, even if Av is given to extinguish
+        if issubclass(model_class, BaseExtRvModel):
+            model_instance = model_class(Rv=rv)
+        else:
+            try:
+                model_instance = model_class()
+            except Exception as e: # pragma: no cover
+                 raise RuntimeError(
+                    f"Failed to initialize model {model_class.__name__} without parameters. "
+                    f"Original error: {e}"
+                )
+        attenuation_factor = model_instance.extinguish(waves_for_model, Av=av_value)
+    elif ebv_value is not None: # Use E(B-V)
+        if issubclass(model_class, BaseExtRvModel):
+            model_instance = model_class(Rv=rv)
+            # This extinguish call will use model_instance.Rv internally
+            attenuation_factor = model_instance.extinguish(waves_for_model, Ebv=ebv_value)
+        else:
+            # Non-R(V) dependent models cannot use E(B-V) to determine A(V)
+            # as they don't have an Rv attribute intrinsically.
+            # The base BaseExtModel.extinguish(Ebv=...) relies on self.Rv.
+            raise ValueError(
+                f"Model {model_class.__name__} is not R(V)-dependent. "
+                f"A(V) must be provided directly via the 'av' parameter "
+                f"when using this model."
+            )
+    else: # Should be caught by the initial check, but as a safeguard
+        raise ValueError("Internal error: No valid extinction parameter determined.") # pragma: no cover
+
+    flux_dereddened = flux / attenuation_factor
+    return flux_dereddened

--- a/dust_extinction/tests/test_deredden.py
+++ b/dust_extinction/tests/test_deredden.py
@@ -1,0 +1,255 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from astropy import units as u
+from astropy.modeling.core import InputParameterError as AstropyInputParameterError
+
+from dust_extinction.parameter_averages import CCM89, O94, F99 # Added F99 for more variety
+from dust_extinction.averages import G03_SMCBar # A non-RV dependent model
+from dust_extinction.deredden import deredden_flux
+from dust_extinction.baseclasses import BaseExtModel, BaseExtRvModel
+
+
+# --- Dummy Models for specific test cases ---
+class DummyRvModel(BaseExtRvModel):
+    Rv_range = [2.0, 6.0]  # Overriding the range for the dummy, if necessary
+    x_range = [0.1, 10.0]   # Specify valid range for this dummy model
+
+    def __init__(self, Rv=3.1):
+        # BaseExtRvModel's __init__ does not take Rv.
+        # It inherits from BaseExtModel, whose __init__ takes no model-specific args.
+        # The Rv parameter is defined on BaseExtRvModel.
+        # Setting self.Rv here uses the Parameter descriptor.
+        super().__init__() 
+        self.Rv = Rv
+
+    def evaluate(self, x_in, Rv):
+        # When the model is called (e.g., model(x)), astropy's modeling framework
+        # takes parameters from the model's param_sets (like self.Rv) and passes
+        # them as keyword arguments to evaluate. So, 'Rv' here will be the
+        # value of the Rv parameter of the model instance.
+        return x_in / Rv
+
+class DummyNonRvModel(BaseExtModel):
+    x_range = [0.1, 10.0] # 1/micron
+    # No Rv parameter in __init__ or as attribute
+
+    def evaluate(self, x_in, **kwargs):
+        # A(x)/A(V) = x (simple, not physical, for testing)
+        return x_in
+
+# --- Fixtures ---
+@pytest.fixture
+def basic_inputs():
+    """Provide basic inputs (no units) for testing."""
+    wavelengths = np.array([0.4, 0.5, 0.6]) # microns
+    flux = np.array([1.0, 1.5, 2.0])
+    # Matched to the expected values from previous successful test runs for CCM89, Rv=3.1, Ebv=0.2
+    # Av = 0.62
+    # Original flux before reddening for these tests was approx:
+    # 1.0 / 2.307862 = 0.4333
+    # 1.5 / 2.847138 = 0.5268
+    # 2.0 / 3.356565 = 0.5959
+    return wavelengths, flux, {"ebv": 0.2, "rv": 3.1}, {"av": 0.62}
+
+@pytest.fixture
+def basic_inputs_units():
+    """Provide basic inputs with astropy units."""
+    wavelengths = np.array([0.4, 0.5, 0.6]) * u.micron
+    flux = np.array([1.0, 1.5, 2.0]) * u.Jy
+    return wavelengths, flux, {"ebv": 0.2, "rv": 3.1}, {"av": 0.62 * u.mag} # Av can have mag units
+
+# --- Tests for deredden_flux ---
+
+def test_deredden_flux_ebv_rv_dependent_no_units(basic_inputs):
+    """Test deredden_flux with E(B-V) for R(V)-dependent model (CCM89), no units."""
+    wavelengths, flux, params_ebv, _ = basic_inputs
+    dered_flux_val = deredden_flux(wavelengths, flux, model_class=CCM89,
+                                   ebv=params_ebv["ebv"], rv=params_ebv["rv"])
+    assert isinstance(dered_flux_val, np.ndarray)
+    # Expected values from previous successful test runs with CCM89, Rv=3.1, Ebv=0.2
+    expected_dered_flux = np.array([2.307862, 2.847138, 3.356565])
+    assert_allclose(dered_flux_val, expected_dered_flux, rtol=1e-5)
+
+def test_deredden_flux_ebv_rv_dependent_with_units(basic_inputs_units):
+    """Test deredden_flux with E(B-V) for R(V)-dependent model (CCM89), with units."""
+    wavelengths, flux, params_ebv, _ = basic_inputs_units
+    dered_flux_q = deredden_flux(wavelengths, flux, model_class=CCM89,
+                                 ebv=params_ebv["ebv"], rv=params_ebv["rv"])
+    assert isinstance(dered_flux_q, u.Quantity)
+    assert dered_flux_q.unit == flux.unit
+    expected_dered_flux_values = np.array([2.307862, 2.847138, 3.356565])
+    assert_allclose(dered_flux_q.value, expected_dered_flux_values, rtol=1e-5)
+
+def test_deredden_flux_av_rv_dependent_with_units(basic_inputs_units):
+    """Test deredden_flux with A(V) for R(V)-dependent model (F99), with units."""
+    wavelengths, flux, _, params_av = basic_inputs_units
+    # Using F99 to show av works with other Rv models too
+    dered_flux_q = deredden_flux(wavelengths, flux, model_class=F99, av=params_av["av"])
+    assert isinstance(dered_flux_q, u.Quantity)
+    assert dered_flux_q.unit == flux.unit
+    # Expected values for F99, Av=0.62 at 0.4, 0.5, 0.6 micron
+    # F99 model, Rv=3.1 (default for F99 if not specified, deredden_flux passes rv=3.1 by default)
+    # A(V) = 0.62
+    # model = F99(Rv=3.1)
+    # wl_inv_micron = 1.0 / wavelengths.to_value(u.micron)
+    # axav = model(wl_inv_micron)
+    # alambda = axav * 0.62
+    # expected_dered_flux = flux.value * np.power(10.0, 0.4 * alambda)
+    expected_dered_flux_values = np.array([2.254119, 2.846173, 3.281264])
+    assert_allclose(dered_flux_q.value, expected_dered_flux_values, rtol=1e-5)
+
+
+def test_deredden_flux_av_non_rv_dependent_model(basic_inputs_units):
+    """Test deredden_flux with A(V) for a non-R(V)-dependent model (G03_SMCBar)."""
+    wavelengths, flux, _, params_av = basic_inputs_units
+    # G03_SMCBar is an average model, does not take Rv
+    dered_flux_q = deredden_flux(wavelengths, flux, model_class=G03_SMCBar, av=params_av["av"])
+    assert isinstance(dered_flux_q, u.Quantity)
+    assert dered_flux_q.unit == flux.unit
+    # Check it runs and produces different results from CCM89 due to different model
+    ccm89_flux = deredden_flux(wavelengths, flux, model_class=CCM89, av=params_av["av"])
+    assert not np.allclose(dered_flux_q.value, ccm89_flux.value)
+    # Expected for G03_SMCBar, Av=0.62
+    # model = G03_SMCBar()
+    # ...
+    expected_dered_flux_values = np.array([2.412804, 2.886646, 3.326536])
+    assert_allclose(dered_flux_q.value, expected_dered_flux_values, rtol=1e-5)
+
+
+def test_deredden_flux_ebv_non_rv_dependent_error(basic_inputs_units):
+    """Test error when using E(B-V) with a non-R(V)-dependent model."""
+    wavelengths, flux, params_ebv, _ = basic_inputs_units
+    with pytest.raises(ValueError, match="Model G03_SMCBar is not R\(V\)-dependent. A\(V\) must be provided"):
+        deredden_flux(wavelengths, flux, model_class=G03_SMCBar,
+                      ebv=params_ebv["ebv"], rv=params_ebv["rv"])
+
+def test_deredden_flux_different_rv_explicit(basic_inputs_units):
+    """Test deredden_flux with an explicit non-default Rv value."""
+    wavelengths, flux, params_ebv, _ = basic_inputs_units
+    rv_custom = 5.0
+    dered_flux_rv5 = deredden_flux(wavelengths, flux, model_class=CCM89,
+                                   ebv=params_ebv["ebv"], rv=rv_custom)
+    dered_flux_rv31 = deredden_flux(wavelengths, flux, model_class=CCM89,
+                                    ebv=params_ebv["ebv"], rv=3.1)
+    assert isinstance(dered_flux_rv5, u.Quantity)
+    assert np.all(dered_flux_rv5.value > dered_flux_rv31.value) # Higher Rv -> more extinction correction
+
+def test_round_trip_rv_model(basic_inputs_units):
+    """Test redden then deredden with an R(V)-dependent model (CCM89)."""
+    wavelengths, original_flux, params_ebv, _ = basic_inputs_units
+    rv = params_ebv["rv"]
+    ebv = params_ebv["ebv"]
+
+    model = CCM89(Rv=rv)
+    attenuation_factor = model.extinguish(wavelengths, Ebv=ebv)
+    reddened_flux = original_flux * attenuation_factor
+
+    dereddened_flux = deredden_flux(wavelengths, reddened_flux, model_class=CCM89,
+                                    ebv=ebv, rv=rv)
+    assert_allclose(dereddened_flux.value, original_flux.value, rtol=1e-6)
+
+def test_round_trip_non_rv_model_av(basic_inputs_units):
+    """Test redden then deredden with a non-R(V)-model using A(V)."""
+    wavelengths, original_flux, _, params_av = basic_inputs_units
+    av = params_av["av"]
+
+    model = G03_SMCBar() # Non-Rv model
+    attenuation_factor = model.extinguish(wavelengths, Av=av.value if isinstance(av, u.Quantity) else av)
+    reddened_flux = original_flux * attenuation_factor
+
+    dereddened_flux = deredden_flux(wavelengths, reddened_flux, model_class=G03_SMCBar, av=av)
+    assert_allclose(dereddened_flux.value, original_flux.value, rtol=1e-6)
+
+
+def test_parameter_errors(basic_inputs_units):
+    """Test errors for missing or invalid av/ebv parameters."""
+    wavelengths, flux, _, _ = basic_inputs_units
+    with pytest.raises(ValueError, match="Either 'av' or 'ebv' must be provided."):
+        deredden_flux(wavelengths, flux, model_class=CCM89)
+    with pytest.raises(ValueError, match="A\(V\) = -0.1 must be non-negative."):
+        deredden_flux(wavelengths, flux, model_class=CCM89, av=-0.1)
+    with pytest.raises(ValueError, match="E\(B-V\) = -0.1 must be non-negative."):
+        deredden_flux(wavelengths, flux, model_class=CCM89, ebv=-0.1, rv=3.1)
+
+def test_wavelength_out_of_range_ccm89(basic_inputs_units):
+    """Test wavelength out of range for CCM89."""
+    wavelengths_short = np.array([0.01]) * u.micron
+    wavelengths_long = np.array([10.0]) * u.micron
+    _, flux, _, params_av = basic_inputs_units
+
+    # Using CCM89's known range [0.3, 10.0] 1/micron -> [0.1, 3.33] micron
+    with pytest.raises(ValueError, match=r"Input x outside of range defined for CCM89"):
+        deredden_flux(wavelengths_short, flux[0], model_class=CCM89, av=params_av["av"])
+    with pytest.raises(ValueError, match=r"Input x outside of range defined for CCM89"):
+        deredden_flux(wavelengths_long, flux[0], model_class=CCM89, av=params_av["av"])
+
+def test_invalid_model_class_type():
+    """Test passing a non-model class type."""
+    with pytest.raises(TypeError, match="model_class must be a subclass of BaseExtModel."):
+        deredden_flux(0.5*u.micron, 1.0*u.Jy, model_class=str, av=0.1)
+
+def test_av_precedence(basic_inputs_units):
+    """Test that A(V) takes precedence if both A(V) and E(B-V) are given."""
+    wavelengths, flux, params_ebv, params_av = basic_inputs_units
+    # Use CCM89, provide Av and also Ebv/Rv that would give a *different* Av
+    av_priority = params_av["av"] # 0.62
+    ebv_ignored = 0.1 # This would give Av = 0.31 if Rv=3.1
+    rv_ignored = 3.1
+
+    # Calculate expected flux if only av_priority was used
+    model_for_av = CCM89(Rv=3.1) # rv in deredden_flux is 3.1 by default
+    atten_av = model_for_av.extinguish(wavelengths, Av=av_priority.value if isinstance(av_priority, u.Quantity) else av_priority)
+    expected_flux_av = flux / atten_av
+    
+    dered_flux_with_both = deredden_flux(wavelengths, flux, model_class=CCM89,
+                                         av=av_priority, ebv=ebv_ignored, rv=rv_ignored)
+    assert_allclose(dered_flux_with_both.value, expected_flux_av.value, rtol=1e-6)
+
+# Tests with Dummy Models to check internal logic paths
+
+def test_dummy_rv_model_ebv(basic_inputs_units):
+    """Test deredden_flux with DummyRvModel using E(B-V)."""
+    wavelengths, flux, params_ebv, _ = basic_inputs_units
+    rv = params_ebv["rv"]
+    ebv = params_ebv["ebv"]
+    
+    dered_flux_q = deredden_flux(wavelengths, flux, model_class=DummyRvModel, ebv=ebv, rv=rv)
+    
+    # DummyRvModel: A(x)/A(V) = x / Rv_instance
+    # model_instance.extinguish(Ebv=ebv) uses model_instance.Rv
+    # A(V)_calc = model_instance.Rv * ebv
+    # A_lambda = (x_inv_micron / model_instance.Rv) * A(V)_calc
+    #          = (x_inv_micron / rv) * (rv * ebv) = x_inv_micron * ebv
+    x_inv_micron = (1.0 / wavelengths.to(u.micron).value)
+    alambda_manual = x_inv_micron * ebv
+    attenuation_manual = 10**(-0.4 * alambda_manual)
+    expected_dered_flux_values = flux.value / attenuation_manual
+    
+    assert_allclose(dered_flux_q.value, expected_dered_flux_values, rtol=1e-5)
+
+
+def test_dummy_non_rv_model_av(basic_inputs_units):
+    """Test deredden_flux with DummyNonRvModel using A(V)."""
+    wavelengths, flux, _, params_av = basic_inputs_units
+    av = params_av["av"]
+
+    dered_flux_q = deredden_flux(wavelengths, flux, model_class=DummyNonRvModel, av=av)
+
+    # DummyNonRvModel: A(x)/A(V) = x
+    # A_lambda = x_inv_micron * Av
+    x_inv_micron = (1.0 / wavelengths.to(u.micron).value)
+    alambda_manual = x_inv_micron * (av.value if isinstance(av, u.Quantity) else av)
+    attenuation_manual = 10**(-0.4 * alambda_manual)
+    expected_dered_flux_values = flux.value / attenuation_manual
+    
+    assert_allclose(dered_flux_q.value, expected_dered_flux_values, rtol=1e-5)
+
+
+def test_dummy_non_rv_model_ebv_error(basic_inputs_units):
+    """Test error using E(B-V) with DummyNonRvModel."""
+    wavelengths, flux, params_ebv, _ = basic_inputs_units
+    with pytest.raises(ValueError, match="Model DummyNonRvModel is not R\(V\)-dependent. A\(V\) must be provided"):
+        deredden_flux(wavelengths, flux, model_class=DummyNonRvModel,
+                      ebv=params_ebv["ebv"], rv=params_ebv["rv"])


### PR DESCRIPTION
This branch created by Google Julius.  Testing to see how Julius does.

Starting query:

> Create a function that has the same capabilities as the IDL ccm_unred code using the dust_extinction ccm89 model.

Result

> feat: Add ccm_unred function for flux dereddening
> 
> This commit introduces a new utility function `ccm_unred` in a
> new module `dust_extinction.deredden`. This function provides a
> Python equivalent to the IDL `ccm_unred.pro` routine, allowing you
> to deredden observed fluxes given wavelengths, E(B-V), and R(V).
> 
> The function uses the specified dust extinction model (defaulting to
> CCM89) to calculate the attenuation and then applies the correction
> to the input flux. It supports inputs as plain numpy arrays or
> astropy Quantity objects.
> 
> Key changes:
> - Created `dust_extinction/deredden.py` with the `ccm_unred` function.
> - Integrated `ccm_unred` into the main package namespace in
>   `dust_extinction/__init__.py`.
> - Added comprehensive unit tests for `ccm_unred` in
>   `dust_extinction/tests/test_deredden.py`, covering various
>   scenarios, input types, and error handling.
> - Updated documentation:
>     - Added API documentation for the `deredden` module.
>     - Included a usage example and plot for `ccm_unred` in the
>       narrative documentation on extinguishing/unextinguishing data.

Revised query

> Create a function that has the same capabilities as the IDL ccm_unred code using bug works with any dust_extinction extinction model.

Result

> This commit refactors the previously added dereddening utility:
> - Renamed from `ccm_unred` to `deredden_flux` to reflect its ability to work with various extinction models.
> - Modified the function signature and logic to accept either `av` (A(V)) or `ebv` (E(B-V) with `rv`). `av` takes precedence and allows the function to work with non-R(V)-dependent models.
> - If `ebv` is used, the model must be R(V)-dependent, or an error is raised.
> 
> Changes include:
> - Updated `dust_extinction/deredden.py` with the new `deredden_flux` implementation.
> - Updated `dust_extinction/__init__.py` to export `deredden_flux`.
> - Significantly revised the unit tests in `dust_extinction/tests/test_deredden.py` to cover the new functionality, parameter handling (av, ebv, rv), non-R(V) models, and various error conditions. All tests pass.
> - Updated documentation:
>     - API documentation for `deredden_flux`.
>     - Narrative documentation in `extinguish.rst` revised with new function name, parameter explanations, and examples for both R(V)-dependent and non-R(V)-dependent model usage.