### PR TITLE
Updates to setuptools-scm breaks dust_extinction install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 
 # License details
-license = { file = "licenses/LICENSE.rst" }
+license = { file = "LICENSE" }
 
 # Project URL
 urls = { "Home" = "http://dust-extinction.readthedocs.io/" }


### PR DESCRIPTION
Our package (Synthesizer) uses `dust_extinction` for some dust attenuation laws. Our workflows started to fail about an hour ago and it turns out the issue is linked to `dust_extinction` and a `setuptools-scm` update from roughly an hour ago.

**The Problem:**
The existing `pyproject.toml` for dust\_extinction-1.5 only defines the `[build-system]` section and defers all project metadata to `setup.cfg`/`setup.py`. With the release of **setuptools-scm v9.0.3**, PEP 621 enforcement was tightened: any project listing `setuptools_scm` in `[build-system].requires` **must** declare its version source explicitly in the `[project]` table (via `dynamic = ["version"]`) or provide a `[tool.setuptools_scm]` section. Without this, pip’s isolated metadata build fails with the error:

```
ValueError: pyproject.toml: setuptools-scm is present in [build-system].requires
but dynamic=['version'] is not set in [project]. Either add dynamic=['version']
 to [project] or add a [tool.setuptools_scm] section.
```

This issue only appeared for users on environments with setuptools-scm ≥ 9.0.3, since earlier versions silently fell back to reading `setup.cfg`/`setup.py` for metadata.

**The Cause:**
PEP 517 build isolation and stricter setuptools-scm checks no longer fall back to `setup.cfg` for metadata. Because `pyproject.toml` lacked a `[project]` table, pip could not discover the package name or version, triggering the failure.

**The Solution:**
Add a complete PEP 621 `[project]` section in `pyproject.toml`, sourcing metadata from the existing `setup.cfg` entries and declaring the version as dynamic.

This now successfully installs from the fork.
