### PR TITLE
updating so _curve_F99_method uses the calling models x_rangey

### DIFF
--- a/dust_extinction/averages.py
+++ b/dust_extinction/averages.py
@@ -451,6 +451,7 @@ class G03_SMCBar(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -578,6 +579,7 @@ class G03_LMCAvg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -708,6 +710,7 @@ class G03_LMC2(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -1639,6 +1642,7 @@ class G24_SMCAvg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -1771,6 +1775,7 @@ class G24_SMCBumps(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -1905,6 +1910,7 @@ class C25_M31Avg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )
 
 
@@ -2035,4 +2041,5 @@ class G26_M33Avg(BaseExtModel):
             gamma,
             optnir_axav_x,
             optnir_axav_y,
+            x_range=self.x_range,
         )

--- a/dust_extinction/parameter_averages.py
+++ b/dust_extinction/parameter_averages.py
@@ -350,8 +350,7 @@ class F99(BaseExtRvModel):
     Rv_range = [2.0, 6.0]
     x_range = x_range_F99
 
-    @staticmethod
-    def evaluate(x, Rv):
+    def evaluate(self, x, Rv):
         """
         F99 function
 
@@ -429,6 +428,7 @@ class F99(BaseExtRvModel):
             gamma,
             optnir_axav_x,
             optnir_axebv_y / Rv,
+            x_range=self.x_range,
         )
 
 
@@ -498,8 +498,7 @@ class F04(BaseExtRvModel):
     Rv_range = [2.0, 6.0]
     x_range = x_range_F04
 
-    @staticmethod
-    def evaluate(x, Rv):
+    def evaluate(self, x, Rv):
         """
         F04 function
 
@@ -576,6 +575,7 @@ class F04(BaseExtRvModel):
             gamma,
             optnir_axav_x,
             optnir_axebv_y / Rv,
+            x_range=self.x_range,
         )
 
 

--- a/dust_extinction/shapes.py
+++ b/dust_extinction/shapes.py
@@ -24,6 +24,7 @@ def _curve_F99_method(
     optnir_axav_x,
     optnir_axav_y,
     fm90_version="C3",
+    x_range=None,
 ):
     """
     Function to return extinction using F99 method
@@ -67,6 +68,9 @@ def _curve_F99_method(
     fm90_version: str
         "C3" for standard FM90, "B3" for FM90_B3 for true bump amplitude version
 
+    x_range: 2 floats, optional
+        allowed min/max of x for validation. If None, uses FM90 default range.
+
     Returns
     -------
     axav: np array (float)
@@ -100,6 +104,10 @@ def _curve_F99_method(
         fm90_model = FM90_B3(C1=C1, C2=C2, B3=bump_param, C4=C4, xo=xo, gamma=gamma)
     else:
         fm90_model = FM90(C1=C1, C2=C2, C3=bump_param, C4=C4, xo=xo, gamma=gamma)
+    # us the x_range instead of the default if input
+    if x_range is not None:
+        fm90_model.x_range = x_range
+
     # evaluate model and get results in A(x)/A(V)
     axav_fm90 = fm90_model(xuv / u.micron) / Rv + 1.0
 


### PR DESCRIPTION
The _curve_F99_method uses the FM90 internally and the x_range for that model is used.  This function is used for a number of models that may or do have different x_range values.  In addition the user can override the x_range on a model.  The mismatch can cause issues as was documented in issue #262. 

This PR fixes this so _curve_F99_method uses the calling model's x_range by passing it explicitly. 

Closes #262.