### PR TITLE
bumping python versions

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -28,11 +28,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
         # Test python version 3.x
-        python-ver: [10, 11, 12]
+        python-ver: [11, 12, 13]
 
         # Specify which tox environments to test in this list.
         # tox-env: [cov, alldeps, devdeps, astropylts]
-        tox-env: [alldeps]
+        # tox-env: alldeps
     steps:
     - uses: actions/checkout@v4
     - name: Set up python 3.${{ matrix.python-ver }} with tox environment py3${{ matrix.python-ver }}-${{ matrix.tox-env }} on ${{ matrix.os }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-test{,-alldeps}{,-cov}
+    py{311,312,313}-test{,-alldeps}{,-cov}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
Moving to 3.11, 3.12, and 3.13.    3.10 is now on security only updates.

Also removing unneeded tox configuration line that was causing the matrix tests to fail.