### PR TITLE
REL: automate artifact building, testing, and publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish
+on:
+  push:
+    tags: v*
+  pull_request:
+    paths:
+    - .github/workflows/publish.yml
+    - pyproject.toml
+    - setup.py
+    - MANIFEST.in
+
+permissions: {}
+
+jobs:
+  build:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@a138926f6e4f9667d1306c24f24f5bdcaa01fbab # v2.5.0
+    with:
+      upload_to_pypi: false
+      save_artifacts: true
+      test_extras: test
+      test_command: pytest --pyargs dust_extinction
+
+  pypi-publish:
+    name: Publish
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dust_extinction
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      with:
+        name: artifacts
+        path: dist
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ name = "dust_extinction"
 description = "Interstellar Dust Extinction Models"
 requires-python = ">=3.10"
 readme = { file = "README.rst", content-type = "text/x-rst" }
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
   { name = "Karl D. Gordon", email = "kgordon@stsci.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-  "setuptools>=62.1",
+  "setuptools>=77.0.1",
   "setuptools_scm[toml]>=8.0.0",
-  "wheel",]
+]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
close #276

note that automating publication on push for tags that start with `v` is common enough that I bundled it here, but the way I did it still requires a couple manual tweaks from owners.
ref: https://docs.pypi.org/trusted-publishers/

You could also choose to only automate building and testing, and still perform publication manually from your trustee laptop, using for instance a combination of github-cli and uv:

```shell
gh release download v1.2.3
uv publish
```
