### PR TITLE
DEP: add missing lower bound on direct dependencies

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -33,6 +33,12 @@ jobs:
         # Specify which tox environments to test in this list.
         # tox-env: [cov, alldeps, devdeps, astropylts]
         # tox-env: alldeps
+
+        include:
+          - os: ubuntu-24.04
+            python-ver: 11
+            tox-env: oldestdeps
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up python 3.${{ matrix.python-ver }} with tox environment py3${{ matrix.python-ver }}-${{ matrix.tox-env }} on ${{ matrix.os }}

--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -65,24 +65,6 @@ jobs:
   #     run: |
   #       tox -e py38-devdeps
 
-  # LTS version test
-  lts_test:
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up python for astropy lts test
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
-    - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Test with tox
-      run: |
-        tox -e py311-astropylts
-
   # Coverage test
   cov_test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,22 @@ exclude_lines = [
         E203,
         E501,
     """
+
+[tool.uv]
+# constrain packages that *may* be required transitively and without
+# an explicit lower bound to prevent build errors with ancient versions
+# when running oldestdeps
+constraint-dependencies = [
+    "setuptools>=70.0.0",
+]
+# the following transitive dependencies should *never* be built from source in CI:
+# prefer versions that have compatible binaries to strictly oldest-compatible ones
+no-build-package = [
+    # via astropy
+    "pyyaml",
+
+    # via matplotlib
+    "pillow",
+    "contourpy",
+    "kiwisolver",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,19 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Karl D. Gordon", email = "kgordon@stsci.edu" },
 ]
-dependencies = ["astropy", "scipy"]
+dependencies = [
+    "astropy>=6.2.1",
+    "numpy>=1.26.0",
+    "scipy>=1.13.0",
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
-    "pytest",
-    "pytest-doctestplus",
-    "pytest-cov",
-    "matplotlib"
+    "pytest>=8.0.0",
+    "pytest-doctestplus>=1.7.1",
+    "pytest-cov>=6.0.0",
+    "matplotlib>=3.7.0"
 ]
 docs = [
     "sphinx",

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
     linkcheck
     codestyle
 requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
+    tox >=4.47.3
+    tox-uv >=1.33.1
 isolated_build = true
 
 [testenv]
@@ -34,6 +34,11 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
+
+# oldestdeps always resolve all dependencies to their oldest compatible versions
+# (including transitive ones)
+uv_resolution =
+    oldestdeps: lowest
 
 # The following provides some specific pinnings for key packages
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -34,12 +34,9 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    astropylts: with the latest astropy LTS (currently v5.0)
 
 # The following provides some specific pinnings for key packages
 deps =
-    astropylts: astropy==5.0.*
-
     devdeps: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
I noticed that numpy wasn't explicitly declared as a direct dependency. Then I noticed that no direct dependency had an explicit lower bound. Both of these properties are desirable when forcing dependency resolution to oldest-compatible versions, which is emerging as a viable strategy to maximise environment reproducibility without a lock file.
Note however than the lower bounds I used are just *guesses* and I haven't invested much effort in checking they actually work. This is normally checked in CI using the `oldestdeps` tox factor which I see is partially defined here, but not in any useful extent.
I also dropped the `astropylts` factor because astropy doesn't have LTS versions anymore.