### PR TITLE
adding in scattering parameters for WD01 models

### DIFF
--- a/dust_extinction/grain_models.py
+++ b/dust_extinction/grain_models.py
@@ -182,6 +182,8 @@ class WD01(BaseExtGrainModel):
         sindxs = np.argsort(np.absolute(self.data_x - 1.0 / 0.55))
 
         self.data_axav = a["cext"].data / a["cext"].data[sindxs[0]]
+        self.data_albedo = a["albedo"]
+        self.data_g = a["g"]
 
         # accuracy of the data based on calculations
         self.data_tolerance = 1e-6


### PR DESCRIPTION
Useful when investigating the behavior of Qabs and Qsca where Qabs = Qext * albedo among other things.